### PR TITLE
fix: implement consistent track ordering in sequencer (Kick at bottom)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -430,7 +430,6 @@
       "integrity": "sha512-TCb3qYOC/uXKZCo56cJ6N9sHeWdFhyVqrbbYfFjTi09081T6jllgHDZL5Ms7gOMNY8KywWGGbhxwvzeA0RwTgA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "21.2.0",
         "eslint-scope": "^9.0.0"
@@ -460,7 +459,6 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.11.tgz",
       "integrity": "sha512-CpyK3XxcjuYj8cl/eaKZYxrIpVOG7Ci49YSPIzyY5bzxMv7znOoRuPnEMV/EENfiQ12IraWCBh9dd7g37PBjOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -666,7 +664,6 @@
       "integrity": "sha512-yaGEpckqgOemcHkoWeH92i9eNrcbr9iE/dnxL+Du6s9spTAXJ2jjtYfszhmowuQZkCK5rjecMb8ctNtHlaGCjg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/architect": "0.2102.0",
         "@angular-devkit/core": "21.2.0",
@@ -714,7 +711,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.11.tgz",
       "integrity": "sha512-3Z3SABXpzM6fkX21WCRP6IwrjxNQVHM/3Fk2OXScExOAzpaOpS2bDgS4NB6rtCbmzKL/NFSp7ZPIZigfdqnWGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -731,7 +727,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.11.tgz",
       "integrity": "sha512-/KdE0kPQr24K/aNsdIDS2or555+8CrQxyRB5MxPKy3/8d6EvilEY/UN7pB7A5xgRQtUPMea08ZzLFJVp1qNbDA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -745,7 +740,6 @@
       "integrity": "sha512-qp/LgptDYJvpEHVVdwBEtkcbybre/ftanu0qJMpH3mu5FC4HEEOChl+9m7UVrmL4jC1ZkoZcgtzsGKAQr8mw2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.29.0",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -778,7 +772,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.11.tgz",
       "integrity": "sha512-EULAfQ0m/I9hZJes74OFlrnfDWqlfV0esE0CkHehO5IEF9rd769+dfuGEAJAzrz+/6Q3PhS0bWDYiT68z1H8Ag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -824,7 +817,6 @@
       "integrity": "sha512-Yy82TXpgwyZidPyakgnVBa9Bzg6cT7MQNX2ezpc9tw26jLaj1M/XMIcAHgD9ZH9kk39peZWPP6FUF6SNRYZqdw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.29.0",
         "@types/babel__core": "7.20.5",
@@ -849,7 +841,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.11.tgz",
       "integrity": "sha512-Uz/KwGjSEvbE8J9kNSSetzxhBWjCXv9OuxH1w2WkW6jLNU3vgvzuKX7SXDyUys6KJv5TqkClJ9BLeU11QbmJdw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -934,7 +925,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2239,7 +2229,6 @@
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
         "@inquirer/confirm": "^5.1.21",
@@ -4835,7 +4824,6 @@
       "integrity": "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4881,7 +4869,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -4989,7 +4976,6 @@
       "integrity": "sha512-ujT0Je8GI5BJWi+/mMoR0wxwVEQaxM+pi30xuMiJETlX80OPovb2p9E8ss87gnSVtYXtJoU9U1Cowcr6w2FE0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5032,7 +5018,6 @@
       "integrity": "sha512-BqZEsnPGdYpgyEIkDC1BadNY8oMwckftxBT+C8W0g1iKPdeqKZBtTfnvcq0nf60u7MkjFO8RBvpRGZBPw4L2ow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.55.0",
@@ -5279,7 +5264,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5637,7 +5621,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5853,7 +5836,6 @@
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -6753,7 +6735,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7130,7 +7111,6 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7657,7 +7637,6 @@
       "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8148,8 +8127,7 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.2.0.tgz",
       "integrity": "sha512-b16WZG/pFEFj8qRW1ss7nDuNGYz9ji8BDGj7fJNrROauk5rj/diO3KPOuyIpcgUChdC+c0PfQ8iUk4nHE+EN4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jose": {
       "version": "6.1.3",
@@ -8284,7 +8262,6 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -8850,7 +8827,6 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -10163,7 +10139,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10647,7 +10622,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -11433,8 +11407,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tuf-js": {
       "version": "4.1.0",
@@ -11484,7 +11457,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11715,7 +11687,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11791,7 +11762,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -12155,7 +12125,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -12174,8 +12143,7 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.0.tgz",
       "integrity": "sha512-LqLPpIQANebrlxY6jKcYKdgN5DTXyyHAKnnWWjE5pPfEQ4n7j5zn7mOEEpwNZVKGqx3kKKmvplEmoBrvpgROTA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     }
   }
 }

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.ts
@@ -1,24 +1,25 @@
-import {Component, Inject, OnDestroy, OnInit} from '@angular/core';
-import {Beat} from '../../../domain/beat';
-import {BehaviorSubject, Subject, takeUntil, tap} from "rxjs";
-import {BpmInputComponent} from "../bpm-input/bpm-input.component";
-import {SelectInputComponent} from "../select-input/select-input.component";
-import {Track} from "../../../domain/track";
-import {IManageBeatsToken} from "../../../infrastructure/injection-tokens/i-manage-beat.token";
+import { Option } from "effect";
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { Beat } from '../../../domain/beat';
+import { BehaviorSubject, Subject, takeUntil, tap } from "rxjs";
+import { BpmInputComponent } from "../bpm-input/bpm-input.component";
+import { SelectInputComponent } from "../select-input/select-input.component";
+import { Track } from "../../../domain/track";
+import { IManageBeatsToken } from "../../../infrastructure/injection-tokens/i-manage-beat.token";
 import IManageBeats from "../../../domain/ports/i-manage-beats";
-import {AUDIO_ENGINE} from "../../../infrastructure/injection-tokens/audio-engine.token";
-import {IAudioEngine} from "../../../domain/ports/i-audio-engine";
-import {FormsModule} from "@angular/forms";
-import {NumberOfSteps} from "../../../domain/number-of-steps";
-import {TempoAdapterService} from "../../../infrastructure/adapters/tempo-control/tempo-adapter.service";
-import {PlayerEventsService} from "../../services/player.events.service";
-import {BPM} from "../../../domain/bpm";
-import {StepIndex} from "../../../domain/step-index";
-import {TranslateModule} from "@ngx-translate/core";
-import {Steps} from "../../../domain/steps";
-import {ExportModalComponent} from "../export-modal/export-modal.component";
-import {ExportOptions} from "../../../domain/export-options";
-import {AudioExporterService} from "../../../infrastructure/adapters/audio-engine/audio-exporter.service";
+import { AUDIO_ENGINE } from "../../../infrastructure/injection-tokens/audio-engine.token";
+import { IAudioEngine } from "../../../domain/ports/i-audio-engine";
+import { FormsModule } from "@angular/forms";
+import { NumberOfSteps } from "../../../domain/number-of-steps";
+import { TempoAdapterService } from "../../../infrastructure/adapters/tempo-control/tempo-adapter.service";
+import { PlayerEventsService } from "../../services/player.events.service";
+import { BPM } from "../../../domain/bpm";
+import { StepIndex } from "../../../domain/step-index";
+import { TranslateModule } from "@ngx-translate/core";
+import { Steps } from "../../../domain/steps";
+import { ExportModalComponent } from "../export-modal/export-modal.component";
+import { ExportOptions } from "../../../domain/export-options";
+import { AudioExporterService } from "../../../infrastructure/adapters/audio-engine/audio-exporter.service";
 
 @Component({
   selector: 'sequencer',
@@ -46,10 +47,10 @@ export class SequencerComponent implements OnInit, OnDestroy {
   isExportModalOpen = false;
 
   constructor(@Inject(IManageBeatsToken) private readonly _beatsManager: IManageBeats,
-              @Inject(AUDIO_ENGINE) public readonly soundService: IAudioEngine,
-              protected readonly tempoService: TempoAdapterService,
-              private readonly playerEvents: PlayerEventsService,
-              private readonly audioExporterService: AudioExporterService) {
+    @Inject(AUDIO_ENGINE) public readonly soundService: IAudioEngine,
+    protected readonly tempoService: TempoAdapterService,
+    private readonly playerEvents: PlayerEventsService,
+    private readonly audioExporterService: AudioExporterService) {
     this.beatBehaviourSubject = new Subject<Beat>();
 
     this.playerEvents.playPause$
@@ -91,21 +92,47 @@ export class SequencerComponent implements OnInit, OnDestroy {
     this.selectBeat(beats[0]);
   }
 
+
   selectBeat(beatToSelect: Beat): void {
+    const allTracks = beatToSelect.tracks.map(track => ({
+      ...track,
+      steps: new Steps(track.steps.steps)
+    }));
+
+    const kicks: any[] = [];
+    const snares: any[] = [];
+    const hats: any[] = [];
+    const others: any[] = [];
+
+    allTracks.forEach((t: any) => {
+      const name = t.name?.toUpperCase() || "";
+      const midi = t.midiNote?.value?.toString().toUpperCase() || "";
+
+      if (name.includes('KICK') || midi.includes('KICK')) {
+        kicks.push(t);
+      } else if (name.includes('SNARE') || midi.includes('SNARE')) {
+        snares.push(t);
+      } else if (name.includes('HAT') || midi.includes('HAT')) {
+        hats.push(t);
+      } else {
+        others.push(t);
+      }
+    });
+    const finalOrder = [...others, ...hats, ...snares, ...kicks];
     this.beat = {
       ...beatToSelect,
-      tracks: beatToSelect.tracks.map(track => ({
-        ...track,
-        steps: new Steps(track.steps.steps)
-      }))
+      tracks: finalOrder as any
     };
     this.beatBehaviourSubject.next(this.beat);
     this.customBeatSubject.next(this.beat);
   }
 
+
   beatChange($event: string) {
     const beatToSelect = this.genres.get(this.selectedGenreLabel)!.find(x => x.label === $event);
-    this.selectBeat(beatToSelect!);
+    if (beatToSelect) {
+      this.selectBeat(beatToSelect);
+    }
   }
 
   stepClick = (track: Track, stepIndex: StepIndex, value: boolean): void => {
@@ -128,7 +155,7 @@ export class SequencerComponent implements OnInit, OnDestroy {
   changeBeatBpm($event: number) {
     this.soundService.pause();
     this.tempoService.setBpm(BPM($event));
-    this.beat = this.beat = {
+    this.beat = {
       ...this.beat,
       bpm: BPM($event),
     };

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.ts
@@ -94,34 +94,35 @@ export class SequencerComponent implements OnInit, OnDestroy {
 
 
   selectBeat(beatToSelect: Beat): void {
-    const allTracks = beatToSelect.tracks.map(track => ({
+    const allTracks: Track[] = beatToSelect.tracks.map(track => ({
       ...track,
       steps: new Steps(track.steps.steps)
     }));
 
-    const kicks: any[] = [];
-    const snares: any[] = [];
-    const hats: any[] = [];
-    const others: any[] = [];
+    const drums: Track[] = [];
+    const other: Track[] = [];
 
-    allTracks.forEach((t: any) => {
-      const name = t.name?.toUpperCase() || "";
-      const midi = t.midiNote?.value?.toString().toUpperCase() || "";
-
-      if (name.includes('KICK') || midi.includes('KICK')) {
-        kicks.push(t);
-      } else if (name.includes('SNARE') || midi.includes('SNARE')) {
-        snares.push(t);
-      } else if (name.includes('HAT') || midi.includes('HAT')) {
-        hats.push(t);
+    allTracks.forEach((t: Track) => {
+      if (Option.isSome(t.midiNote)) {
+        drums.push(t);
       } else {
-        others.push(t);
+        other.push(t);
       }
     });
-    const finalOrder = [...others, ...hats, ...snares, ...kicks];
-    this.beat = {
+    drums.sort((a: Track, b: Track) => {
+      const aMidi = (a.midiNote as any).value?.value || 0;
+      const bMidi = (b.midiNote as any).value?.value || 0;
+      return bMidi - aMidi;
+
+    });
+
+    const onlyKicks = drums.filter(t => (t.name?.toUpperCase().includes('KICK')));
+    const nonKicks = drums.filter(t => !(t.name?.toUpperCase().includes('KICK')));
+    const finalOrder = [...other, ...nonKicks, ...onlyKicks];
+
+  this.beat = {
       ...beatToSelect,
-      tracks: finalOrder as any
+      tracks: finalOrder
     };
     this.beatBehaviourSubject.next(this.beat);
     this.customBeatSubject.next(this.beat);

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.ts
@@ -110,9 +110,9 @@ export class SequencerComponent implements OnInit, OnDestroy {
       }
     });
     drums.sort((a: Track, b: Track) => {
-      const aMidi = (a.midiNote as any).value?.value || 0;
-      const bMidi = (b.midiNote as any).value?.value || 0;
-      return bMidi - aMidi;
+      const aMidi = Option.getOrElse(a.midiNote, ()=>0);
+      const bMidi = Option.getOrElse(b.midiNote, ()=>0);
+      return (bMidi as number) - (aMidi as number);
 
     });
 


### PR DESCRIPTION


This PR addresses the issue where audio tracks were displayed in an inconsistent vertical order across different beats. It ensures that the tracks follow a logical musical hierarchy.

Modified `SequencerComponent.selectBeat` to implement a robust sorting strategy.
- Used an "array grouping and concatenation" approach to guarantee the order:
  **Instruments/Others** (at the top)
  **Hi-Hats
  **Snares**
  **Kicks** (at the bottom)
- Added fallback logic to check both `midiNote` values and track names to ensure consistency even if metadata is missing.

- Verified on various genres (Dub, Techno, Psytrance).
- Confirmed that the "Kick" drum is always positioned at the bottom of the grid.
- Ensured that switching between beats maintains the correct vertical alignment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sequencer now arranges and displays tracks in a consistent, deterministic order (drums sorted by pitch, kick instruments placed predictably), improving workflow reliability.
  * Beat selection now checks for missing beats and handles unavailable selections gracefully without errors.
  * BPM updates correctly apply to beat settings and are emitted to update dependent components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->