### PR TITLE
refacto (tracks) : add types on mp3filepath and wavfilepath

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -431,7 +431,6 @@
       "integrity": "sha512-TCb3qYOC/uXKZCo56cJ6N9sHeWdFhyVqrbbYfFjTi09081T6jllgHDZL5Ms7gOMNY8KywWGGbhxwvzeA0RwTgA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "21.2.0",
         "eslint-scope": "^9.0.0"
@@ -461,7 +460,6 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.11.tgz",
       "integrity": "sha512-CpyK3XxcjuYj8cl/eaKZYxrIpVOG7Ci49YSPIzyY5bzxMv7znOoRuPnEMV/EENfiQ12IraWCBh9dd7g37PBjOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -667,7 +665,6 @@
       "integrity": "sha512-yaGEpckqgOemcHkoWeH92i9eNrcbr9iE/dnxL+Du6s9spTAXJ2jjtYfszhmowuQZkCK5rjecMb8ctNtHlaGCjg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/architect": "0.2102.0",
         "@angular-devkit/core": "21.2.0",
@@ -715,7 +712,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.11.tgz",
       "integrity": "sha512-3Z3SABXpzM6fkX21WCRP6IwrjxNQVHM/3Fk2OXScExOAzpaOpS2bDgS4NB6rtCbmzKL/NFSp7ZPIZigfdqnWGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -732,7 +728,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.11.tgz",
       "integrity": "sha512-/KdE0kPQr24K/aNsdIDS2or555+8CrQxyRB5MxPKy3/8d6EvilEY/UN7pB7A5xgRQtUPMea08ZzLFJVp1qNbDA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -746,7 +741,6 @@
       "integrity": "sha512-qp/LgptDYJvpEHVVdwBEtkcbybre/ftanu0qJMpH3mu5FC4HEEOChl+9m7UVrmL4jC1ZkoZcgtzsGKAQr8mw2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.29.0",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -779,7 +773,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.11.tgz",
       "integrity": "sha512-EULAfQ0m/I9hZJes74OFlrnfDWqlfV0esE0CkHehO5IEF9rd769+dfuGEAJAzrz+/6Q3PhS0bWDYiT68z1H8Ag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -825,7 +818,6 @@
       "integrity": "sha512-Yy82TXpgwyZidPyakgnVBa9Bzg6cT7MQNX2ezpc9tw26jLaj1M/XMIcAHgD9ZH9kk39peZWPP6FUF6SNRYZqdw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.29.0",
         "@types/babel__core": "7.20.5",
@@ -850,7 +842,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.11.tgz",
       "integrity": "sha512-Uz/KwGjSEvbE8J9kNSSetzxhBWjCXv9OuxH1w2WkW6jLNU3vgvzuKX7SXDyUys6KJv5TqkClJ9BLeU11QbmJdw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -935,7 +926,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2240,7 +2230,6 @@
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
         "@inquirer/confirm": "^5.1.21",
@@ -4860,7 +4849,6 @@
       "integrity": "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4906,7 +4894,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -5014,7 +5001,6 @@
       "integrity": "sha512-ujT0Je8GI5BJWi+/mMoR0wxwVEQaxM+pi30xuMiJETlX80OPovb2p9E8ss87gnSVtYXtJoU9U1Cowcr6w2FE0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5057,7 +5043,6 @@
       "integrity": "sha512-BqZEsnPGdYpgyEIkDC1BadNY8oMwckftxBT+C8W0g1iKPdeqKZBtTfnvcq0nf60u7MkjFO8RBvpRGZBPw4L2ow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.55.0",
@@ -5304,7 +5289,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5662,7 +5646,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5878,7 +5861,6 @@
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -6778,7 +6760,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7155,7 +7136,6 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7682,7 +7662,6 @@
       "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8173,8 +8152,7 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.2.0.tgz",
       "integrity": "sha512-b16WZG/pFEFj8qRW1ss7nDuNGYz9ji8BDGj7fJNrROauk5rj/diO3KPOuyIpcgUChdC+c0PfQ8iUk4nHE+EN4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jose": {
       "version": "6.1.3",
@@ -8309,7 +8287,6 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -8875,7 +8852,6 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -10198,7 +10174,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10682,7 +10657,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -11468,8 +11442,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tuf-js": {
       "version": "4.1.0",
@@ -11519,7 +11492,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11750,7 +11722,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11826,7 +11797,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -12190,7 +12160,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -12209,8 +12178,7 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.0.tgz",
       "integrity": "sha512-LqLPpIQANebrlxY6jKcYKdgN5DTXyyHAKnnWWjE5pPfEQ4n7j5zn7mOEEpwNZVKGqx3kKKmvplEmoBrvpgROTA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     }
   }
 }

--- a/frontend/src/app/domain/midi.filename.ts
+++ b/frontend/src/app/domain/midi.filename.ts
@@ -1,4 +1,4 @@
-export type MidiFilename = `${string}${string}.mid`;
+export type MidiFilename = `${string}.mid`;
 
 export function toMidiFilename(name: string): MidiFilename {
   if (!/^[^.\s][^\\/:*?"<>|]*\.mid$/i.test(name)) {

--- a/frontend/src/app/domain/mp3.filename.ts
+++ b/frontend/src/app/domain/mp3.filename.ts
@@ -1,0 +1,11 @@
+export type Mp3Filename = `${string}.mp3`;
+
+export type Mp3FilePath = `${string}/${Mp3Filename}` | Mp3Filename;
+
+export function toMp3FilePath(path: string): Mp3FilePath {
+  if (!/^(.*\/)?[^\/]+\.mp3$/i.test(path.trim())) {
+    throw new Error(`Invalid mp3 file path: ${path}`);
+  }
+
+  return path as Mp3FilePath;
+}

--- a/frontend/src/app/domain/track.ts
+++ b/frontend/src/app/domain/track.ts
@@ -2,18 +2,27 @@ import {Steps} from "./steps";
 import {NumberOfSteps} from "./number-of-steps";
 import {MidiDrumType} from "./midi-drum-type";
 import {Option} from "effect";
+import {Mp3FilePath, toMp3FilePath} from "./mp3.filename";
+import {toWavFilePath, WavFilePath} from "./wav.filename";
 
 const allowedStepLengths = [8, 16, 32, 64];
 
 export class Track {
   readonly name: string;
-  readonly fileName: string;
+  readonly fileName: Mp3FilePath | WavFilePath;
   readonly steps: Steps;
   readonly numberOfSteps: NumberOfSteps;
   readonly midiNote: Option.Option<MidiDrumType>;
 
   constructor(name: string, fileName: string, steps: boolean[], midiNote: Option.Option<MidiDrumType> = Option.none()) {
-    this.fileName = fileName;
+    if (fileName.toLowerCase().endsWith('.mp3')) {
+      this.fileName = toMp3FilePath(fileName);
+    } else if (fileName.toLowerCase().endsWith('.wav')) {
+      this.fileName = toWavFilePath(fileName);
+    } else {
+      throw new Error(`Unsupported audio format: ${fileName}`);
+    }
+
     this.name = name;
 
     if(!allowedStepLengths.includes(steps.length)) {

--- a/frontend/src/app/domain/wav.filename.ts
+++ b/frontend/src/app/domain/wav.filename.ts
@@ -1,0 +1,11 @@
+export type WavFilename = `${string}.wav`;
+
+export type WavFilePath = `${string}/${WavFilename}` | WavFilename;
+
+export function toWavFilePath(path: string): WavFilePath {
+  if (!/^(.*\/)?[^\/]+\.wav$/i.test(path.trim())) {
+    throw new Error(`Invalid mp3 file path: ${path}`);
+  }
+
+  return path as WavFilePath;
+}

--- a/frontend/src/app/infrastructure/adapters/beat-source/beat-adapter.service.spec.ts
+++ b/frontend/src/app/infrastructure/adapters/beat-source/beat-adapter.service.spec.ts
@@ -5,6 +5,7 @@ import {Observable, of} from "rxjs";
 import {TestBed} from "@angular/core/testing";
 import {CompactBeat} from "./compact-beat";
 import {jsonFileReaderToken} from "../../injection-tokens/json-file-reader.token";
+import {toMp3FilePath} from "../../../domain/mp3.filename";
 
 describe("Beat adapter service", () => {
 
@@ -17,17 +18,17 @@ describe("Beat adapter service", () => {
         "tracks": [
           {
             "name": "Snare",
-            "fileName": "metal/snare.mp3",
+            "fileName": toMp3FilePath("metal/snare.mp3"),
             "steps": "____X_______X___"
           },
           {
             "name": "Hats",
-            "fileName": "metal/crash.mp3",
+            "fileName": toMp3FilePath("metal/carsh.mp3"),
             "steps": "X___X___X___X___"
           },
           {
             "name": "Kick",
-            "fileName": "metal/kick.mp3",
+            "fileName":  toMp3FilePath("metal/kick.mp3"),
             "steps": "XXXXXXXXXXXXXXXX"
           }
         ]

--- a/frontend/src/app/infrastructure/adapters/beat-source/compact-beat.mapper.spec.ts
+++ b/frontend/src/app/infrastructure/adapters/beat-source/compact-beat.mapper.spec.ts
@@ -3,13 +3,14 @@ import {Beat} from "../../../domain/beat";
 import {Track} from "../../../domain/track";
 import {BPM} from "../../../domain/bpm";
 import {Effect} from "effect";
+import {toMp3FilePath} from "../../../domain/mp3.filename";
 
 describe('Compact beat mapper tests', () => {
   it("Should map beat to compact beat to beat again", () => {
     const beat : Beat = {
       genre: "test", label: "", bpm: BPM(150), tracks: [
-        new Track("", "", [true, false, false, true, true, false, false, true, true, false, false, true, true, false, false, true]),
-        new Track("", "", [true, false, false, true, true, false, false, true, true, false, false, true, true, false, false, true]),
+        new Track("", toMp3FilePath("test.mp3"), [true, false, false, true, true, false, false, true, true, false, false, true, true, false, false, true]),
+        new Track("", toMp3FilePath("test.mp3"), [true, false, false, true, true, false, false, true, true, false, false, true, true, false, false, true]),
       ]
     };
 

--- a/frontend/src/app/ui/router.spec.ts
+++ b/frontend/src/app/ui/router.spec.ts
@@ -19,6 +19,7 @@ import {IMIDI} from "../infrastructure/injection-tokens/i-midi.token";
 import {MidiExportService} from "../infrastructure/adapters/midi-export/midi-exporter.service";
 import {AUDIO_EXPORT} from "../infrastructure/injection-tokens/audio-export.token";
 import {AudioExportAdapter} from "../infrastructure/adapters/audio-export/audio-export.adapter";
+import {toMp3FilePath} from "../domain/mp3.filename";
 
 const beatsProvider = {
   provide: IManageBeatsToken,
@@ -62,7 +63,7 @@ describe('Router', () => {
                 label: 'Classic',
                 bpm: BPM(128),
                 tracks: [
-                  new Track("","", [true, false, true, false, true, false, true, false])
+                  new Track("",toMp3FilePath("kick.mp3"), [true, false, true, false, true, false, true, false])
                 ]
               }
             ])

--- a/frontend/test/app/domain/track.spec.vite.ts
+++ b/frontend/test/app/domain/track.spec.vite.ts
@@ -2,12 +2,13 @@ import {expect, test} from 'vitest'
 import {MidiDrumType} from "../../../src/app/domain/midi-drum-type";
 import {Option} from "effect";
 import {Track} from "../../../src/app/domain/track";
+import {toMp3FilePath} from "../../../src/app/domain/mp3.filename";
 
 test("Should not be created with unsupported step count", () => {
-  expect(() => new Track("Kick", "", [true, false], Option.some(MidiDrumType.BASS_DRUM_1))).toThrow();
+  expect(() => new Track("Kick", toMp3FilePath("test.wav"), [true, false], Option.some(MidiDrumType.BASS_DRUM_1))).toThrow();
 });
 
 test("Should be created with right step number", () => {
-  const track = new Track("Kick", "", [true, false, false, false, true, false, false, false, true, false, false, false, true, false, false, false], Option.some(MidiDrumType.BASS_DRUM_1));
+  const track = new Track("Kick", toMp3FilePath("test.mp3"), [true, false, false, false, true, false, false, false, true, false, false, false, true, false, false, false], Option.some(MidiDrumType.BASS_DRUM_1));
   expect(track).toBeDefined();
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tracks now validate that audio files are in MP3 or WAV format; unsupported audio formats are rejected with an error.

* **Tests**
  * Updated test fixtures to use proper audio file path validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Babali42/DrumBeatRepo/pull/409)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->