### PR TITLE
#413 Add a toggle export with tail

### DIFF
--- a/frontend/src/app/domain/export-options/audio-export-options.ts
+++ b/frontend/src/app/domain/export-options/audio-export-options.ts
@@ -6,10 +6,12 @@ export interface AudioExportOptions {
   format: ExportFormat;
   loopCount: LoopCount;
   quality: ExportQuality;
+  exportWithTail: Boolean;
 }
 
 export const DEFAULT_EXPORT_OPTIONS: AudioExportOptions = {
   format: 'wav',
   loopCount: 1,
-  quality: 192
+  quality: 192,
+  exportWithTail: true
 };

--- a/frontend/src/app/domain/export-options/audio-export-options.ts
+++ b/frontend/src/app/domain/export-options/audio-export-options.ts
@@ -6,7 +6,7 @@ export interface AudioExportOptions {
   format: ExportFormat;
   loopCount: LoopCount;
   quality: ExportQuality;
-  exportWithTail: Boolean;
+  exportWithTail: boolean;
 }
 
 export const DEFAULT_EXPORT_OPTIONS: AudioExportOptions = {

--- a/frontend/src/app/infrastructure/adapters/audio-export/audio-export.adapter.ts
+++ b/frontend/src/app/infrastructure/adapters/audio-export/audio-export.adapter.ts
@@ -20,8 +20,8 @@ export class AudioExportAdapter implements IAudioExport {
 
     const rawBuffers = await this.loadAllBuffers(tracks);
     const maxBufferDuration = this.getMaxBufferDuration(rawBuffers);
-    const totalWithTail = totalDurationSeconds + maxBufferDuration;
-    const totalSamples = Math.ceil(totalWithTail * sampleRate);
+    const total = totalDurationSeconds + ((options.exportWithTail) ? maxBufferDuration * 2 : 0);
+    const totalSamples = Math.ceil(total * sampleRate);
 
     const offlineContext = new OfflineAudioContext(2, totalSamples, sampleRate);
     const stepDurationSeconds = this.tempoService.stepDuration;

--- a/frontend/src/app/ui/components/modals/export-audio-modal/export-audio-modal.component.html
+++ b/frontend/src/app/ui/components/modals/export-audio-modal/export-audio-modal.component.html
@@ -21,6 +21,11 @@
           </select>
         </div>
 
+        <div class="form-group">
+          <label for="exportWithTail">{{ 'export.exportWithTail' | translate }}</label>
+          <input id="exportWithTail" type="checkbox" [(ngModel)]="options.exportWithTail" />
+        </div>
+
         <!-- TODO: MP3 support -->
         <!-- <div class="form-group">
           <label for="format">Format</label>

--- a/frontend/src/app/ui/components/modals/export-audio-modal/export-audio-modal.component.spec.ts
+++ b/frontend/src/app/ui/components/modals/export-audio-modal/export-audio-modal.component.spec.ts
@@ -54,8 +54,8 @@ describe('ExportAudioModalComponent', () => {
     expect(component.options.format).toBe('wav');
   });
 
-  it('should have 1 loop as default duration', () => {
-    expect(component.options.loopCount).toBe(1);
+  it('default export with tail option should be true', () => {
+    expect(component.options.exportWithTail).toBeTruthy();
   });
 
   it('should emit close event when close button is clicked', () => {
@@ -149,7 +149,8 @@ describe('ExportAudioModalComponent', () => {
     expect(component.export.emit).toHaveBeenCalledWith({
       format: 'wav',
       loopCount: 4,
-      quality: 320
+      quality: 320,
+      exportWithTail: true,
     });
   });
 });

--- a/frontend/src/assets/i18n/ar.json
+++ b/frontend/src/assets/i18n/ar.json
@@ -13,7 +13,8 @@
     "loops": "حلقات",
     "cancel": "إلغاء",
     "export": "تصدير",
-    "wavButton": "تصدير إلى .wav"
+    "wavButton": "تصدير إلى .wav",
+    "exportWithTail": "Export with tail"
   },
   "exportMidi": {
     "title": "تصدير الإيقاع إلى ملف MIDI",

--- a/frontend/src/assets/i18n/de.json
+++ b/frontend/src/assets/i18n/de.json
@@ -13,7 +13,8 @@
     "loops": "Schleifen",
     "cancel": "Abbrechen",
     "export": "Exportieren",
-    "wavButton": "Als .wav exportieren"
+    "wavButton": "Als .wav exportieren",
+    "exportWithTail": "Export with tail"
   },
   "exportMidi": {
     "title": "Rhythmus als MIDI-Datei exportieren",

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -13,7 +13,8 @@
     "loops": "loops",
     "cancel": "Cancel",
     "export": "Export",
-    "wavButton": "Export to .wav"
+    "wavButton": "Export to .wav",
+    "exportWithTail": "Export with tail"
   },
   "exportMidi": {
     "title": "Export Beat to MIDI file",

--- a/frontend/src/assets/i18n/es.json
+++ b/frontend/src/assets/i18n/es.json
@@ -13,7 +13,8 @@
     "loops": "bucles",
     "cancel": "Cancelar",
     "export": "Exportar",
-    "wavButton": "Exportar a .wav"
+    "wavButton": "Exportar a .wav",
+    "exportWithTail": "Export with tail"
   },
   "exportMidi": {
     "title": "Exportar ritmo a archivo MIDI",

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -13,7 +13,8 @@
     "loops": "boucles",
     "cancel": "Annuler",
     "export": "Exporter",
-    "wavButton": "Exporter en .wav"
+    "wavButton": "Exporter en .wav",
+    "exportWithTail": "Exporter avec le dernier sample en entier"
   },
   "exportMidi": {
     "title": "Exporter le rythme en fichier MIDI",

--- a/frontend/src/assets/i18n/it.json
+++ b/frontend/src/assets/i18n/it.json
@@ -13,7 +13,8 @@
     "loops": "cicli",
     "cancel": "Annulla",
     "export": "Esporta",
-    "wavButton": "Esporta in .wav"
+    "wavButton": "Esporta in .wav",
+    "exportWithTail": "Export with tail"
   },
   "exportMidi": {
     "title": "Esporta ritmo in file MIDI",

--- a/frontend/src/assets/i18n/ja.json
+++ b/frontend/src/assets/i18n/ja.json
@@ -13,7 +13,8 @@
     "loops": "ループ",
     "cancel": "キャンセル",
     "export": "エクスポート",
-    "wavButton": ".wavにエクスポート"
+    "wavButton": ".wavにエクスポート",
+    "exportWithTail": "Export with tail"
   },
   "exportMidi": {
     "title": "リズムをMIDIファイルにエクスポート",

--- a/frontend/src/assets/i18n/pt.json
+++ b/frontend/src/assets/i18n/pt.json
@@ -13,7 +13,8 @@
     "loops": "loops",
     "cancel": "Cancelar",
     "export": "Exportar",
-    "wavButton": "Exportar para .wav"
+    "wavButton": "Exportar para .wav",
+    "exportWithTail": "Export with tail"
   },
   "exportMidi": {
     "title": "Exportar ritmo para arquivo MIDI",

--- a/frontend/src/assets/i18n/ru.json
+++ b/frontend/src/assets/i18n/ru.json
@@ -13,7 +13,8 @@
     "loops": "циклов",
     "cancel": "Отмена",
     "export": "Экспорт",
-    "wavButton": "Экспорт в .wav"
+    "wavButton": "Экспорт в .wav",
+    "exportWithTail": "Export with tail"
   },
   "exportMidi": {
     "title": "Экспорт ритма в MIDI-файл",

--- a/frontend/src/assets/i18n/zh.json
+++ b/frontend/src/assets/i18n/zh.json
@@ -13,7 +13,8 @@
     "loops": "循环",
     "cancel": "取消",
     "export": "导出",
-    "wavButton": "导出为 .wav"
+    "wavButton": "导出为 .wav",
+    "exportWithTail": "Export with tail"
   },
   "exportMidi": {
     "title": "导出节奏到MIDI文件",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toggleable "Export with Tail" option in the audio export dialog, allowing users to include or exclude trailing audio during export (enabled by default).

* **Internationalization**
  * Added translations for the new export option across all supported languages (English, German, Spanish, French, Italian, Japanese, Portuguese, Russian, Arabic, and Chinese).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Babali42/DrumBeatRepo/pull/414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->