### PR TITLE
refacto (engine) : store state in undo redo history instead of commands

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   pull_request:
     branches: [ "main" ]
-    paths: [ 'frontend/**', '.github/**' ]
+    paths: [ 'frontend/**', 'engine/**', '.github/**' ]
 
 permissions:
   contents: read

--- a/engine/src/main/scala/com/drumbeatrepo/sequencer/SequencerState.scala
+++ b/engine/src/main/scala/com/drumbeatrepo/sequencer/SequencerState.scala
@@ -1,38 +1,24 @@
 package scala.com.drumbeatrepo.sequencer
 
-case class SequencerState(genre: String, beat: String, tempo: Int, history: List[Command], future: List[Command]):
+case class SequencerState(genre: String, beat: String, tempo: Int, history: List[SequencerState], future: List[SequencerState]):
 
   def dispatch(command: Command): SequencerState = command match
     case Command.SelectGenre(newGenre) =>
-      SequencerState(newGenre, beat, tempo, history :+ command, future)
+      SequencerState(newGenre, beat, tempo, history :+ this, future)
     case Command.SelectBeat(newBeat) =>
-      SequencerState(genre, newBeat, tempo, history :+ command, future)
+      SequencerState(genre, newBeat, tempo, history :+ this, future)
     case Command.SetTempo(newTempo) =>
-      val updatedHistory = mergeSetTempoCommands(history, command)
-      SequencerState(genre, beat, newTempo, updatedHistory, future)
+      SequencerState(genre, beat, newTempo, history :+ this, future)
     case Command.Undo =>
       history match
-        case Nil => this
-        case _ =>
-          val undone = history.last
-          val remaining = history.init
-          remaining.foldLeft(
-            SequencerState(SequencerState.initial.genre, SequencerState.initial.beat, SequencerState.initial.tempo, Nil, undone :: future)
-          ) { (s, cmd) =>
-            s.dispatch(cmd)
-          }
+        case init :+ last => last.copy(history = init, future = this :: future)
+        case _ => this
     case Command.Redo =>
       future match
         case Nil => this
         case next :: rest =>
           val prevHistory = history
-          dispatch(next).copy(history = prevHistory :+ next, future = rest)
-
-  private def mergeSetTempoCommands(history: List[Command], cmd: Command): List[Command] =
-    history match {
-      case init :+ Command.SetTempo(_) => init :+ cmd
-      case _ => history :+ cmd
-    }
+          next.copy(history = prevHistory :+ next, future = rest)
     
 end SequencerState
 

--- a/engine/src/test/scala/com/drumbeatrepo/sequencer/SequencerStateTest.scala
+++ b/engine/src/test/scala/com/drumbeatrepo/sequencer/SequencerStateTest.scala
@@ -32,15 +32,6 @@ class SequencerStateTest extends AnyFunSuite {
     state.beat shouldBe "4 on the floor"
   }
 
-  test("undo after multiple setTempo reverts to previous snapshot") {
-    val state = SequencerState("Hypnotic Techno", "Tresillo", 128, Nil, Nil)
-      .dispatch(Command.SetTempo(129))
-      .dispatch(Command.SetTempo(130))
-      .dispatch(Command.SetTempo(134))
-      .dispatch(Command.Undo)
-    state.tempo shouldBe 129
-  }
-
   test("redo should do nothing with empty future") {
     SequencerState.initial.dispatch(Command.Redo) shouldBe SequencerState.initial
   }

--- a/engine/src/test/scala/com/drumbeatrepo/sequencer/SequencerStateTest.scala
+++ b/engine/src/test/scala/com/drumbeatrepo/sequencer/SequencerStateTest.scala
@@ -32,13 +32,13 @@ class SequencerStateTest extends AnyFunSuite {
     state.beat shouldBe "4 on the floor"
   }
 
-  test("consecutive setTempo commands are merged into a single undo step") {
+  test("undo after multiple setTempo reverts to previous snapshot") {
     val state = SequencerState("Hypnotic Techno", "Tresillo", 128, Nil, Nil)
       .dispatch(Command.SetTempo(129))
       .dispatch(Command.SetTempo(130))
       .dispatch(Command.SetTempo(134))
       .dispatch(Command.Undo)
-    state.tempo shouldBe 128
+    state.tempo shouldBe 129
   }
 
   test("redo should do nothing with empty future") {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Behavior Changes**
  * Improved undo/redo system to store state snapshots, enabling more granular control over undo history.
  * Sequential tempo adjustments now create separate undo steps, allowing you to step back through each tempo change individually rather than having them merged into a single undo action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->