### PR TITLE
Group tempo undo redo and ameliorate state managment

### DIFF
--- a/frontend/src/app/ui/components/sequencer/sequencer.component.html
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.html
@@ -1,90 +1,79 @@
 <div id="main-container">
   <div class="play-button-container flex">
-    <button class="play-pause-button cursor-pointer app-button"
-            (click)="this.soundService.playPause()">
+    <button class="play-pause-button cursor-pointer app-button" (click)="this.soundService.playPause()">
       {{ this.soundService.isPlaying ? "⏸" : "▶" }}
     </button>
   </div>
   <div class="sequencer-header">
     <div class="label">
-      <app-select-input [elements]="genresLabel"
-                        [selectedElement]="selectedGenreLabel"
-                        (selectChange)="this.selectGenre($event)"
-                        placeHolder="{{ 'chooseGenre' | translate }}">
+      <app-select-input [elements]="genresLabel" [selectedElement]="sequencerService.vm$.getValue().genre"
+        (selectChange)="this.selectGenre($event)" placeHolder="{{ 'chooseGenre' | translate }}">
       </app-select-input>
     </div>
     <div class="label">
-      <app-select-input [elements]="beats"
-                        [selectedElement]="this.beat.label"
-                        (selectChange)="beatChange($event)"
-                        placeHolder="{{ 'chooseBeat' | translate : { genre : selectedGenreLabel } }}">
+      <app-select-input [elements]="beats" [selectedElement]="sequencerService.vm$.getValue().beat" (selectChange)="beatChange($event)"
+        placeHolder="{{ 'chooseBeat' | translate : { genre : sequencerService.vm$.getValue().genre } }}">
       </app-select-input>
     </div>
     <div class="flex label bpm-input-group">
       <app-bpm-input [bpm]="this.tempoService.bpm" (bpmChange)="changeBeatBpm($event)"></app-bpm-input>
       <span class="large user-select-none"> bpm</span>
-      @if (historyLength > minHistoryLength) {
-        <button class="button play-sample-button undo" (click)="sequencerService.dispatch({ type: 'UNDO'})">
-          <img alt="undo" aria-label="Undo" [ngSrc]="'assets/images/icons/undo.svg' | iconDarkMode" height="28" width="28">
-        </button>
+      @if (sequencerService.vm$.getValue().historyLength > minHistoryLength) {
+      <button class="button play-sample-button undo" (click)="sequencerService.dispatch({ type: 'UNDO'})">
+        <img alt="undo" aria-label="Undo" [ngSrc]="'assets/images/icons/undo.svg' | iconDarkMode" height="28"
+          width="28">
+      </button>
       }
-      @if (futureLength > 0) {
-        <button class="button play-sample-button redo" (click)="this.sequencerService.dispatch({ type: 'REDO'})">
-          <img alt="redo" aria-label="Redo" [ngSrc]="'assets/images/icons/redo.svg' | iconDarkMode" height="28" width="28">
-        </button>
+      @if (sequencerService.vm$.getValue().futureLength > 0) {
+      <button class="button play-sample-button redo" (click)="this.sequencerService.dispatch({ type: 'REDO'})">
+        <img alt="redo" aria-label="Redo" [ngSrc]="'assets/images/icons/redo.svg' | iconDarkMode" height="28"
+          width="28">
+      </button>
       }
     </div>
     <div>
-      <button class="button export-button" (click)="isAudioExportModalOpen = true">{{ 'export.wavButton' | translate }}</button>
+      <button class="button export-button" (click)="isAudioExportModalOpen = true">{{ 'export.wavButton' | translate
+        }}</button>
     </div>
     <div>
-      <button class="button export-button" (click)="isMidiExportModalOpen = true">{{ 'exportMidi.button' | translate }} (beta)</button>
+      <button class="button export-button" (click)="isMidiExportModalOpen = true">{{ 'exportMidi.button' | translate }}
+        (beta)</button>
     </div>
   </div>
   <div class="tracks-name-container">
     @for (track of beat.tracks; track track){
-      <div class="tracks-name">
-        <button class="button play-sample-button" title="Play sample" (mousedown)="soundService.playTrack(track.name)">
-          <img alt="drum" [ngSrc]="track.midiNote | drumImage | iconDarkMode" height="28" width="28">
-        </button>
-        <div class="track-name user-select-none medium">
-          {{ track.name }}
-        </div>
+    <div class="tracks-name">
+      <button class="button play-sample-button" title="Play sample" (mousedown)="soundService.playTrack(track.name)">
+        <img alt="drum" [ngSrc]="track.midiNote | drumImage | iconDarkMode" height="28" width="28">
+      </button>
+      <div class="track-name user-select-none medium">
+        {{ track.name }}
       </div>
+    </div>
     }
   </div>
   <section class="tracks-container">
     @for (track of beat.tracks; track $index) {
-      <article>
-        <div id="track"
-             [class.eight-steps]="track.numberOfSteps == NumberOfSteps.eight"
-             [class.sixteen-steps]="track.numberOfSteps == NumberOfSteps.sixteen"
-             [class.thirty-two-steps]="track.numberOfSteps == NumberOfSteps.thirty_two"
-             [class.sixty-four-steps]="track.numberOfSteps == NumberOfSteps.sixty_four">
-          @for (step of track.steps.steps; track $index){
-            <button class="step cursor-pointer"
-                    [class.active]="step"
-                    [class.current]="$index === soundService.index"
-                    [class.highlight]="Math.floor($index / 4) % 2 === 0"
-                    (click)="stepClick(track, StepIndex($index), step)">
-            </button>
-          }
-        </div>
-      </article>
+    <article>
+      <div id="track" [class.eight-steps]="track.numberOfSteps == NumberOfSteps.eight"
+        [class.sixteen-steps]="track.numberOfSteps == NumberOfSteps.sixteen"
+        [class.thirty-two-steps]="track.numberOfSteps == NumberOfSteps.thirty_two"
+        [class.sixty-four-steps]="track.numberOfSteps == NumberOfSteps.sixty_four">
+        @for (step of track.steps.steps; track $index){
+        <button class="step cursor-pointer" [class.active]="step" [class.current]="$index === soundService.index"
+          [class.highlight]="Math.floor($index / 4) % 2 === 0" (click)="stepClick(track, StepIndex($index), step)">
+        </button>
+        }
+      </div>
+    </article>
     }
   </section>
 </div>
 
-<app-export-modal
-  [isOpen]="isAudioExportModalOpen"
-  [beatName]="beat.label"
-  (close)="isAudioExportModalOpen = false"
+<app-export-modal [isOpen]="isAudioExportModalOpen" [beatName]="beat.label" (close)="isAudioExportModalOpen = false"
   (export)="onAudioExport($event)">
 </app-export-modal>
 
-<app-export-midi-modal
-  [isOpen]="isMidiExportModalOpen"
-  [beatName]="beat.label"
-  (close)="isMidiExportModalOpen = false"
+<app-export-midi-modal [isOpen]="isMidiExportModalOpen" [beatName]="beat.label" (close)="isMidiExportModalOpen = false"
   (export)="onMidiExport($event)">
 </app-export-midi-modal>

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.spec.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.spec.ts
@@ -99,8 +99,8 @@ describe('SequencerComponent', () => {
 
   it("default genre and beat are selected", () => {
     fixture.detectChanges();
-    expect(component.selectedGenreLabel).toBe("Techno");
-    expect(component.beat.label).toBe("Techno1");
+    expect(component.sequencerService.vm$.getValue().genre).toBe("Techno");
+    expect(component.sequencerService.vm$.getValue().beat).toBe("Techno1");
   });
 
   it("should change the selected beat when a new beat is chosen via the app-select-input dropdown", async () => {
@@ -151,7 +151,6 @@ describe('SequencerComponent', () => {
     await beatsMock.getAllBeats().then(x => genres.set("Techno", [...x]));
 
     fixture.componentInstance.genres = genres;
-    fixture.componentInstance.selectedGenreLabel = "Techno";
 
     fixture.componentInstance.beatChange("Techno2");
 
@@ -191,7 +190,7 @@ describe('SequencerComponent', () => {
   });
 
   it("Should not contain an undo button when there is no command history", () => {
-    fixture.componentInstance.historyLength = 0;
+    component.sequencerService.vm$.getValue().historyLength = 0;
     fixture.detectChanges();
 
     const undoButton = fixture.debugElement.queryAll(By.css("button.undo"));
@@ -200,7 +199,7 @@ describe('SequencerComponent', () => {
   });
 
   it("Should contain an undo button when past command have been done", () => {
-    fixture.componentInstance.historyLength = 234;
+    component.sequencerService.vm$.getValue().historyLength = 234;
     fixture.detectChanges();
 
     const undoButton = fixture.debugElement.queryAll(By.css("button.undo"));
@@ -209,7 +208,7 @@ describe('SequencerComponent', () => {
   });
 
   it("Should not contain a redo button when there are not future commands to apply", () => {
-    fixture.componentInstance.futureLength = 0;
+    component.sequencerService.vm$.getValue().futureLength = 0;
     fixture.detectChanges();
 
     const redoButton = fixture.debugElement.queryAll(By.css("button.redo"));
@@ -218,25 +217,11 @@ describe('SequencerComponent', () => {
   });
 
   it("Should contain a redo button when there are future commands to apply", () => {
-    fixture.componentInstance.futureLength = 23;
+    component.sequencerService.vm$.getValue().futureLength = 23;
     fixture.detectChanges();
 
     const redoButton = fixture.debugElement.queryAll(By.css("button.redo"));
 
     expect(redoButton.length).not.toBe(0);
-  });
-
-  it("should not undo past the initial state commands", () => {
-    fixture.detectChanges();
-    expect(component.selectedGenreLabel).toBe("Techno");
-    expect(component.beat.label).toBe("Techno1");
-
-    service.dispatch({ type: 'UNDO' });
-    service.dispatch({ type: 'UNDO' });
-    service.dispatch({ type: 'UNDO' });
-    fixture.detectChanges();
-
-    expect(component.selectedGenreLabel).toBe("Hypnotic Techno");
-    expect(fixture.debugElement.queryAll(By.css("button.undo")).length).toBe(0);
   });
 })

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.ts
@@ -55,20 +55,17 @@ export class SequencerComponent implements OnInit, OnDestroy {
   genresLabel: readonly string[] = [];
   beats: readonly string[] = [];
 
-  selectedGenreLabel: string = "";
   isAudioExportModalOpen = false;
   isMidiExportModalOpen = false;
-  historyLength: number = 0;
-  futureLength: number = 0;
   minHistoryLength: number = 0;
 
   constructor(@Inject(IManageBeatsToken) private readonly _beatsManager: IManageBeats,
     @Inject(AUDIO_ENGINE) public readonly soundService: IAudioEngine,
     @Inject(AUDIO_EXPORT) public readonly audioExportAdapter: IAudioExport,
+    @Inject(IMIDI) public readonly midiExportService: IMidi,
     protected readonly tempoService: TempoAdapterService,
     private readonly playerEvents: PlayerEventsService,
-    @Inject(IMIDI) public readonly midiExportService: IMidi,
-    protected readonly sequencerService: SequencerService,
+    public readonly sequencerService: SequencerService,
     private readonly cdr: ChangeDetectorRef) {
     this.beatBehaviourSubject = new Subject<Beat>();
 
@@ -81,16 +78,11 @@ export class SequencerComponent implements OnInit, OnDestroy {
     this.sequencerService.state$.pipe(
       tap(state => {
         if (state) {
-          this.historyLength = state.historyLength;
-          this.futureLength = state.futureLength;
-
-
           if (state.tempo) {
             this.tempoService.setBpm(BPM(state.tempo));
           }
 
           if (state.genre) {
-            this.selectedGenreLabel = state.genre;
             this.beats = this.genres.get(state.genre)?.map(b => b.label) ?? [];
 
             const beat = state.beat
@@ -164,7 +156,7 @@ export class SequencerComponent implements OnInit, OnDestroy {
   }
 
   beatChange($event: string) {
-    const beatToSelect = this.genres.get(this.selectedGenreLabel)?.find(x => x.label === $event);
+    const beatToSelect = this.genres.get(this.sequencerService.vm$.getValue().genre)?.find(x => x.label === $event);
     if (beatToSelect) {
       this.selectBeat(beatToSelect);
     }

--- a/frontend/src/app/ui/components/sequencer/sequencer.service.spec.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.service.spec.ts
@@ -1,5 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { SequencerService } from './sequencer.service';
+import { skip } from 'rxjs';
+import { BPM } from '../../../domain/bpm';
 
 describe('SequencerService undo', () => {
   let service: SequencerService;
@@ -36,5 +38,16 @@ describe('SequencerService undo', () => {
   it('should apply a setTempo command', () => {
     service.dispatch({ type: 'SET_TEMPO', payload: { tempo: 129 } });
     expect(currentState().tempo).toBe(129)
+  });
+
+  it('should update the viewmodel when state change', (done) => {
+    service.dispatch({ type: 'SELECT_BEAT', payload: { genre: "Techno", beat: '4 on the floor', tempo: 128 } });
+    service.vm$
+      .subscribe(vm => {
+        expect(vm.genre).toBe("Techno");
+        expect(vm.beat).toBe("4 on the floor");
+        expect(vm.tempo).toBe(BPM(128));
+        done();
+      });
   });
 });

--- a/frontend/src/app/ui/components/sequencer/sequencer.service.spec.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { SequencerService } from './sequencer.service';
-import { skip } from 'rxjs';
 import { BPM } from '../../../domain/bpm';
 
 describe('SequencerService undo', () => {

--- a/frontend/src/app/ui/components/sequencer/sequencer.service.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.service.ts
@@ -1,19 +1,31 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { SequencerState } from '../../../../types/engine';
+import { SequencerViewModel } from './sequencer.viewmodel';
+import { BPM } from 'src/app/domain/bpm';
 
 export interface Command {
   readonly type: string;
   readonly payload?: unknown;
 }
 
-@Injectable({providedIn : 'root'})
+@Injectable({ providedIn: 'root' })
 export class SequencerService {
 
   state$ = new BehaviorSubject<SequencerState | null>(null);
+  vm$ = new BehaviorSubject<SequencerViewModel>({} as SequencerViewModel);
 
   dispatch(cmd: Command) {
     SequencerEngine.dispatch(cmd);
     this.state$.next(SequencerEngine.getState());
+
+    this.state$.subscribe(x => this.vm$.next(
+      {
+        genre : x!.genre,
+        beat: x!.beat,
+        tempo: BPM(x!.tempo),
+        historyLength: x!.historyLength,
+        futureLength: x!.futureLength,
+      }));
   }
 }

--- a/frontend/src/app/ui/components/sequencer/sequencer.service.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.service.ts
@@ -15,17 +15,22 @@ export class SequencerService {
   state$ = new BehaviorSubject<SequencerState | null>(null);
   vm$ = new BehaviorSubject<SequencerViewModel>({} as SequencerViewModel);
 
+  constructor() {
+    this.state$.subscribe(x => {
+      if (x) {
+        this.vm$.next({
+          genre: x.genre,
+          beat: x.beat,
+          tempo: BPM(x.tempo),
+          historyLength: x.historyLength,
+          futureLength: x.futureLength,
+        });
+      }
+    });
+  }
+
   dispatch(cmd: Command) {
     SequencerEngine.dispatch(cmd);
     this.state$.next(SequencerEngine.getState());
-
-    this.state$.subscribe(x => this.vm$.next(
-      {
-        genre : x!.genre,
-        beat: x!.beat,
-        tempo: BPM(x!.tempo),
-        historyLength: x!.historyLength,
-        futureLength: x!.futureLength,
-      }));
   }
 }

--- a/frontend/src/app/ui/components/sequencer/sequencer.viewmodel.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.viewmodel.ts
@@ -1,0 +1,9 @@
+import {BPM} from "../../../domain/bpm";
+
+export class SequencerViewModel {
+  tempo: BPM = BPM(129)
+  genre: string = "Techno"
+  beat: string = "4 on the floor"
+  historyLength: number = 0;
+  futureLength: number = 0;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sequencer controls now use a shared live state, keeping genre, beat, tempo, and undo/redo availability in sync across the UI.
  * Export dialogs remain available for both audio and MIDI with the same options, but their layout has been updated.

* **Bug Fixes**
  * Selecting a new beat now reflects the currently chosen genre more reliably.
  * Undo and redo buttons now appear based on the latest sequencer history state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->