### PR TITLE
ci: add scala code coverage to codecov

### DIFF
--- a/.github/actions/scala-test/action.yml
+++ b/.github/actions/scala-test/action.yml
@@ -17,7 +17,7 @@ runs:
       uses: sbt/setup-sbt@v1
 
     - name: Test Scala
-      run: sbt testFull
+      run: sbt coverage testFull coverageReport
       working-directory: engine
       shell: bash
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,11 @@ jobs:
       - name: Validate Scala
         uses: ./.github/actions/scala-test/
 
+      - name: Upload Scala coverage to Codecov
+          uses: codecov/codecov-action@v4
+          with:
+            token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Validate Angular
         uses: ./.github/actions/angular-test/
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,9 @@ jobs:
         uses: ./.github/actions/scala-test/
 
       - name: Upload Scala coverage to Codecov
-          uses: codecov/codecov-action@v4
-          with:
-            token: ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Validate Angular
         uses: ./.github/actions/angular-test/

--- a/engine/project/plugins.sbt
+++ b/engine/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.5.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")

--- a/engine/project/plugins.sbt
+++ b/engine/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.11")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.1.0")

--- a/engine/project/plugins.sbt
+++ b/engine/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.11")

--- a/engine/project/plugins.sbt
+++ b/engine/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.1.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.5.2")


### PR DESCRIPTION
Fixes #480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Scala test runs now generate code coverage reports as part of the test execution.

* **Chores**
  * Added an automated post-test step to upload Scala coverage results to Codecov.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->