### PR TITLE
Add a addTrack button - AddTrack feature WIP

### DIFF
--- a/engine/src/main/scala/com/drumbeatrepo/sequencer/Command.scala
+++ b/engine/src/main/scala/com/drumbeatrepo/sequencer/Command.scala
@@ -58,6 +58,11 @@ object Command:
               .asInstanceOf[Boolean]
           )
         )
+      case "ADD_TRACK" =>
+        val payload = cmd.selectDynamic("payload")
+        val trackJS = payload.selectDynamic("track")
+        val track = Track.fromJS(trackJS);
+        AddTrack(track)
       case "UNDO" => Undo
       case "REDO" => Redo
       case t      => throw new RuntimeException(s"Unknown command: $t")

--- a/engine/src/main/scala/com/drumbeatrepo/sequencer/Command.scala
+++ b/engine/src/main/scala/com/drumbeatrepo/sequencer/Command.scala
@@ -12,6 +12,7 @@ enum Command:
       toStepIndex: Int,
       velocity: Velocity
   )
+  case AddTrack(track: Track)
   case Undo
   case Redo
 

--- a/engine/src/main/scala/com/drumbeatrepo/sequencer/SequencerState.scala
+++ b/engine/src/main/scala/com/drumbeatrepo/sequencer/SequencerState.scala
@@ -69,7 +69,8 @@ case class SequencerState(
             history :+ this,
             future = Nil
           )
-    case Command.Undo =>
+    case Command.AddTrack(track) => this
+    case Command.Undo            =>
       history match
         case init :+ last => last.copy(history = init, future = this :: future)
         case _            => this

--- a/engine/src/main/scala/com/drumbeatrepo/sequencer/SequencerState.scala
+++ b/engine/src/main/scala/com/drumbeatrepo/sequencer/SequencerState.scala
@@ -69,8 +69,13 @@ case class SequencerState(
             history :+ this,
             future = Nil
           )
-    case Command.AddTrack(track) => this
-    case Command.Undo            =>
+    case Command.AddTrack(track) =>
+      copy(
+        tracks = tracks :+ track,
+        history = history :+ this,
+        future = Nil
+      )
+    case Command.Undo =>
       history match
         case init :+ last => last.copy(history = init, future = this :: future)
         case _            => this

--- a/engine/src/test/scala/com/drumbeatrepo/sequencer/SequencerStateTest.scala
+++ b/engine/src/test/scala/com/drumbeatrepo/sequencer/SequencerStateTest.scala
@@ -219,4 +219,32 @@ class SequencerStateTest extends AnyFunSuite {
 
     state.tracks.length shouldBe 1
   }
+
+  test("ADD_TRACK command is parsed from JS") {
+    val cmd = scala.scalajs.js.Dynamic.literal(
+      "type" -> "ADD_TRACK",
+      "payload" -> scala.scalajs.js.Dynamic.literal(
+        "track" -> scala.scalajs.js.Dynamic.literal(
+          "name" -> "Kick",
+          "fileName" -> "Kick.mp3",
+          "midiNote" -> 35,
+          "steps" -> scala.scalajs.js
+            .Array[Boolean](true, false, false, false)
+        )
+      )
+    )
+    Command.fromJS(cmd) shouldBe Command.AddTrack(
+      Track(
+        "Kick",
+        "Kick.mp3",
+        Some(MidiDrumType.ACOUSTIC_BASS_DRUM),
+        List(
+          Velocity.Normal,
+          Velocity.None,
+          Velocity.None,
+          Velocity.None
+        )
+      )
+    )
+  }
 }

--- a/engine/src/test/scala/com/drumbeatrepo/sequencer/SequencerStateTest.scala
+++ b/engine/src/test/scala/com/drumbeatrepo/sequencer/SequencerStateTest.scala
@@ -186,4 +186,37 @@ class SequencerStateTest extends AnyFunSuite {
     )
     Command.fromJS(cmd) shouldBe Command.SetSteps("Kick", 2, 4, Velocity.None)
   }
+
+  test("dispatch AddTrack add a track to a beat") {
+    val state = SequencerState.initial
+      .dispatch(
+        Command.AddTrack(
+          Track(
+            "kick",
+            "kick.mp3",
+            Some(MidiDrumType.BASS_DRUM_1),
+            List(
+              Velocity.Normal,
+              Velocity.None,
+              Velocity.None,
+              Velocity.None,
+              Velocity.Normal,
+              Velocity.None,
+              Velocity.None,
+              Velocity.None,
+              Velocity.Normal,
+              Velocity.None,
+              Velocity.None,
+              Velocity.None,
+              Velocity.Normal,
+              Velocity.None,
+              Velocity.None,
+              Velocity.None
+            )
+          )
+        )
+      );
+
+    state.tracks.length shouldBe 1
+  }
 }

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.html
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.html
@@ -70,6 +70,20 @@
     </article>
     }
   </section>
+  @if(AddTrackFeatureToggle){
+  <section>
+    <div class="flex align-center">
+      <button class="button play-sample-button" title="Play sample" (mousedown)="this.addTrack()">
+        <!-- TODO add a + image -->
+        <img alt="drum" [ngSrc]=" 'e' | iconDarkMode" height="28" width="28">
+      </button>
+      <div class="track-name user-select-none medium ml-10">
+        <!-- TODO translation -->
+        Add a track
+      </div>
+    </div>
+  </section>
+  }
 </div>
 
 <app-export-modal [isOpen]="isAudioExportModalOpen" [beatName]="beat.label" (close)="isAudioExportModalOpen = false"

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.ts
@@ -32,9 +32,6 @@ import { ExportMidiModalComponent } from '../modals/export-midi-modal/export-mid
 import { BrowseAudioSamplesModalComponent } from '../modals/browse-audio-samples-modal/browse-audio-samples-modal.component';
 
 import { SequencerService } from './sequencer.service';
-import { MidiDrumType } from 'src/app/domain/midi-drum-type';
-
-import { Option } from 'effect';
 
 @Component({
   selector: 'sequencer',

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.ts
@@ -105,7 +105,6 @@ export class SequencerComponent implements OnInit, OnDestroy {
     this.sequencerService.initialize().then(() => {
       const firstGenre = this.sequencerService.genresLabel[0];
       this.genreChange(firstGenre);
-      //this.isBrowseAudioSamplesModalOpen = true;
     }).catch(() => {
       console.error("Fail to init sequencer");
     });
@@ -224,23 +223,7 @@ export class SequencerComponent implements OnInit, OnDestroy {
   }
 
   addTrack(): void {
-    const firstTrack = this.sequencerService.vm$.getValue().tracks[0];
-    //TODO : Choose file in a selection
-    //TODO : Map the selected midinote in corresponding param
-    //TODO : load the track file in the sound engine
-    //TODO : avoid duplicated names, cause names are the id huh
-
-    this.sequencerService.dispatch(
-      {
-        type: 'ADD_TRACK', payload: {
-          track: {
-            name: firstTrack.name,
-            fileName: firstTrack.fileName,
-            steps: Array(firstTrack.steps.steps.length).fill(false),
-            midiNote: Option.getOrElse(firstTrack.midiNote, () => MidiDrumType.ACOUSTIC_BASS_DRUM)
-          }
-        }
-      });
+    this.isBrowseAudioSamplesModalOpen = true;
   }
 
   async onAudioExport(options: AudioExportOptions): Promise<void> {

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.ts
@@ -32,6 +32,9 @@ import { ExportMidiModalComponent } from '../modals/export-midi-modal/export-mid
 import { BrowseAudioSamplesModalComponent } from '../modals/browse-audio-samples-modal/browse-audio-samples-modal.component';
 
 import { SequencerService } from './sequencer.service';
+import { MidiDrumType } from 'src/app/domain/midi-drum-type';
+
+import { Option } from 'effect';
 
 @Component({
   selector: 'sequencer',
@@ -45,6 +48,7 @@ export class SequencerComponent implements OnInit, OnDestroy {
   private readonly destroy$ = new Subject<void>;
   protected readonly Math = Math;
   protected readonly NumberOfSteps = NumberOfSteps;
+  protected readonly AddTrackFeatureToggle = false;
 
   //do not undo the state inits
   readonly minHistoryLength = 1;
@@ -217,6 +221,26 @@ export class SequencerComponent implements OnInit, OnDestroy {
   changeBeatBpm($event: number): void {
     this.soundService.pause();
     this.sequencerService.dispatch({ type: 'SET_TEMPO', payload: { tempo: $event } });
+  }
+
+  addTrack(): void {
+    const firstTrack = this.sequencerService.vm$.getValue().tracks[0];
+    //TODO : Choose file in a selection
+    //TODO : Map the selected midinote in corresponding param
+    //TODO : load the track file in the sound engine
+    //TODO : avoid duplicated names, cause names are the id huh
+
+    this.sequencerService.dispatch(
+      {
+        type: 'ADD_TRACK', payload: {
+          track: {
+            name: firstTrack.name,
+            fileName: firstTrack.fileName,
+            steps: Array(firstTrack.steps.steps.length).fill(false),
+            midiNote: Option.getOrElse(firstTrack.midiNote, () => MidiDrumType.ACOUSTIC_BASS_DRUM)
+          }
+        }
+      });
   }
 
   async onAudioExport(options: AudioExportOptions): Promise<void> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ADD_TRACK` command support to create additional sequencer tracks, including history integration for undo/redo.
  * Extended command parsing to recognize `ADD_TRACK` and translate the provided track data into the sequencer format.
  * Added an “Add a track” UI control (when enabled); it now opens the browse audio samples modal.
* **Tests**
  * Added coverage for adding tracks to sequencer state and for `ADD_TRACK` parsing/field mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->