### PR TITLE
chore : rename base export modal into base validate modal

### DIFF
--- a/frontend/src/app/ui/components/modals/base-modal.component.ts
+++ b/frontend/src/app/ui/components/modals/base-modal.component.ts
@@ -1,17 +1,17 @@
-import {Input, Output, EventEmitter, Directive} from '@angular/core';
+import { Input, Output, EventEmitter, Directive } from '@angular/core';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface BaseExportOptions {
+export interface BaseModalOptions {
 
 }
 
 @Directive()
-export class BaseExportModalComponent<T extends BaseExportOptions> {
+export class BaseModalComponent<T extends BaseModalOptions> {
   @Input() isOpen: boolean = false;
   @Input() beatName: string = '';
 
   @Output() close = new EventEmitter<void>();
-  @Output() export = new EventEmitter<T>();
+  @Output() validate = new EventEmitter<T>();
 
   options!: T;
 
@@ -19,8 +19,8 @@ export class BaseExportModalComponent<T extends BaseExportOptions> {
     this.close.emit();
   }
 
-  onExport(): void {
-    this.export.emit(this.options);
+  onValidate(): void {
+    this.validate.emit(this.options);
   }
 
   onOverlayClick(event: MouseEvent): void {

--- a/frontend/src/app/ui/components/modals/export-audio-modal/export-audio-modal.component.html
+++ b/frontend/src/app/ui/components/modals/export-audio-modal/export-audio-modal.component.html
@@ -1,53 +1,55 @@
 @if(isOpen){
-  <div class="modal-overlay" (click)="onOverlayClick($event)">
-    <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="exportDialogTitle">
-      <div class="modal-header">
-        <h2 id="exportDialogTitle">{{ 'export.title' | translate }}</h2>
-        <button class="close-btn" aria-label="Close export dialog" (click)="onClose()">×</button>
-      </div>
+<div class="modal-overlay" (click)="onOverlayClick($event)">
+  <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="exportDialogTitle">
+    <div class="modal-header">
+      <h2 id="exportDialogTitle">{{ 'export.title' | translate }}</h2>
+      <button class="close-btn" aria-label="Close export dialog" (click)="onClose()">×</button>
+    </div>
 
-      <div class="modal-body" [formGroup]="form">
-        <div class="form-group">
-          @let fileName = form.controls.fileName;
+    <div class="modal-body" [formGroup]="form">
+      <div class="form-group">
+        @let fileName = form.controls.fileName;
 
-          <label for="beatName">{{ 'exportMidi.fileName' | translate }}</label>
-          <input id="beatName" type="text" [formControl]="fileName" class="beat-name-input" />
+        <label for="beatName">{{ 'exportMidi.fileName' | translate }}</label>
+        <input id="beatName" type="text" [formControl]="fileName" class="beat-name-input" />
 
-          @if (fileName.invalid && (fileName.dirty || fileName.touched)) {
-            <div>
-              @if (fileName.errors?.['required']) {
-                <small>{{ 'exportMidi.validation.required' | translate }}</small>
-              }
-              @if (fileName.errors?.['pattern']) {
-                <small>{{ 'exportMidi.validation.pattern' | translate }}</small>
-              }
-            </div>
+        @if (fileName.invalid && (fileName.dirty || fileName.touched)) {
+        <div>
+          @if (fileName.errors?.['required']) {
+          <small>{{ 'exportMidi.validation.required' | translate }}</small>
+          }
+          @if (fileName.errors?.['pattern']) {
+          <small>{{ 'exportMidi.validation.pattern' | translate }}</small>
           }
         </div>
-
-        <div class="form-group">
-          @let loopCount = form.controls.loopCount;
-
-          <label for="loopCount">{{ 'export.duration' | translate }}</label>
-          <select id="loopCount" [formControl]="loopCount" class="form-select">
-            @for (count of loopCounts; track count) {
-              <option [value]="count">{{ count }} {{ count > 1 ? ('export.loops' | translate) : ('export.loop' | translate) }}</option>
-            }
-          </select>
-        </div>
-
-        <span>
-          @let exportWithTail = form.controls.exportWithTail;
-
-          <label for="exportWithTail">{{ 'export.exportWithTail' | translate }}</label>
-          <input id="exportWithTail" type="checkbox" [formControl]="exportWithTail" class="ml-10"/>
-        </span>
+        }
       </div>
 
-      <div class="modal-footer">
-        <button class="btn btn-secondary" (click)="onClose()">{{ 'export.cancel' | translate }}</button>
-        <button class="btn btn-primary" (click)="onExport()" [disabled]="!this.form.valid">{{ 'export.export' | translate }}</button>
+      <div class="form-group">
+        @let loopCount = form.controls.loopCount;
+
+        <label for="loopCount">{{ 'export.duration' | translate }}</label>
+        <select id="loopCount" [formControl]="loopCount" class="form-select">
+          @for (count of loopCounts; track count) {
+          <option [value]="count">{{ count }} {{ count > 1 ? ('export.loops' | translate) : ('export.loop' | translate)
+            }}</option>
+          }
+        </select>
       </div>
+
+      <span>
+        @let exportWithTail = form.controls.exportWithTail;
+
+        <label for="exportWithTail">{{ 'export.exportWithTail' | translate }}</label>
+        <input id="exportWithTail" type="checkbox" [formControl]="exportWithTail" class="ml-10" />
+      </span>
+    </div>
+
+    <div class="modal-footer">
+      <button class="btn btn-secondary" (click)="onClose()">{{ 'export.cancel' | translate }}</button>
+      <button class="btn btn-primary" (click)="onValidate()" [disabled]="!this.form.valid">{{ 'export.export' |
+        translate }}</button>
     </div>
   </div>
+</div>
 }

--- a/frontend/src/app/ui/components/modals/export-audio-modal/export-audio-modal.component.spec.ts
+++ b/frontend/src/app/ui/components/modals/export-audio-modal/export-audio-modal.component.spec.ts
@@ -1,8 +1,8 @@
-import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {ExportAudioModalComponent} from './export-audio-modal.component';
-import {By} from '@angular/platform-browser';
-import {provideTranslateService} from '@ngx-translate/core';
-import {toWavFilename} from "../../../../domain/filenames/wav.filepath";
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ExportAudioModalComponent } from './export-audio-modal.component';
+import { By } from '@angular/platform-browser';
+import { provideTranslateService } from '@ngx-translate/core';
+import { toWavFilename } from "../../../../domain/filenames/wav.filepath";
 
 describe('ExportAudioModalComponent', () => {
   let component: ExportAudioModalComponent;
@@ -73,15 +73,15 @@ describe('ExportAudioModalComponent', () => {
     expect(component.close.emit).toHaveBeenCalled();
   });
 
-  it('should emit export event with options when export button is clicked', () => {
-    spyOn(component.export, 'emit');
+  it('should emit validate event with options when export button is clicked', () => {
+    spyOn(component.validate, 'emit');
     component.isOpen = true;
     fixture.detectChanges();
 
-    const exportBtn = fixture.debugElement.query(By.css('.btn-primary'));
-    exportBtn.nativeElement.click();
+    const validateBtn = fixture.debugElement.query(By.css('.btn-primary'));
+    validateBtn.nativeElement.click();
 
-    expect(component.export.emit).toHaveBeenCalled();
+    expect(component.validate.emit).toHaveBeenCalled();
   });
 
   it('should emit close event when cancel button is clicked', () => {
@@ -127,32 +127,32 @@ describe('ExportAudioModalComponent', () => {
     expect(component.options.loopCount).toBe(2);
   });
 
-  it('should emit export with updated options', () => {
-    spyOn(component.export, 'emit');
+  it('should emit validate with updated options', () => {
+    spyOn(component.validate, 'emit');
     component.isOpen = true;
     fixture.detectChanges();
 
     component.form.controls.loopCount.setValue(4);
     fixture.detectChanges();
 
-    const exportBtn = fixture.debugElement.query(By.css('.btn-primary'));
-    exportBtn.nativeElement.click();
+    const validateBtn = fixture.debugElement.query(By.css('.btn-primary'));
+    validateBtn.nativeElement.click();
 
-    expect(component.export.emit).toHaveBeenCalledWith({
+    expect(component.validate.emit).toHaveBeenCalledWith({
       fileName: toWavFilename('file.wav'),
       loopCount: 4,
       exportWithTail: true,
     });
   });
 
-  it('should not emit export event if form is invalid', () => {
-    spyOn(component.export, 'emit');
+  it('should not emit validate event if form is invalid', () => {
+    spyOn(component.validate, 'emit');
     component.isOpen = true;
     fixture.detectChanges();
 
     component.form.controls.fileName.setValue("test.mp3" as any);
-    component.onExport();
+    component.onValidate();
 
-    expect(component.export.emit).not.toHaveBeenCalled();
+    expect(component.validate.emit).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/ui/components/modals/export-audio-modal/export-audio-modal.component.ts
+++ b/frontend/src/app/ui/components/modals/export-audio-modal/export-audio-modal.component.ts
@@ -1,10 +1,10 @@
-import {Component, EventEmitter, inject, Input, OnChanges, Output, SimpleChanges} from '@angular/core';
-import {FormBuilder, FormControl, FormsModule, ReactiveFormsModule, Validators} from '@angular/forms';
-import {CommonModule} from '@angular/common';
-import {AudioExportOptions, DEFAULT_EXPORT_OPTIONS} from '../../../../domain/export-options/audio-export-options';
-import {TranslatePipe} from "@ngx-translate/core";
-import {BaseExportModalComponent} from "../base-export-modal.component";
-import {toWavFilename, WavFilename} from "../../../../domain/filenames/wav.filepath";
+import { Component, EventEmitter, inject, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { FormBuilder, FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { AudioExportOptions, DEFAULT_EXPORT_OPTIONS } from '../../../../domain/export-options/audio-export-options';
+import { TranslatePipe } from "@ngx-translate/core";
+import { BaseModalComponent } from "../base-modal.component";
+import { toWavFilename, WavFilename } from "../../../../domain/filenames/wav.filepath";
 
 @Component({
   selector: 'app-export-modal',
@@ -13,7 +13,7 @@ import {toWavFilename, WavFilename} from "../../../../domain/filenames/wav.filep
   templateUrl: "./export-audio-modal.component.html",
   styleUrl: "../../../../../styles/modals/modal.base.scss"
 })
-export class ExportAudioModalComponent extends BaseExportModalComponent<AudioExportOptions> implements OnChanges {
+export class ExportAudioModalComponent extends BaseModalComponent<AudioExportOptions> implements OnChanges {
   private readonly fb = inject(FormBuilder);
 
   loopCounts: readonly number[] = [1, 2, 4];
@@ -22,14 +22,14 @@ export class ExportAudioModalComponent extends BaseExportModalComponent<AudioExp
   @Input() override beatName: string = "file";
 
   @Output() override close = new EventEmitter<void>();
-  @Output() override export = new EventEmitter<AudioExportOptions>();
+  @Output() override validate = new EventEmitter<AudioExportOptions>();
   form = this.fb.nonNullable.group({
     fileName: new FormControl<WavFilename>(toWavFilename(this.beatName + ".wav"), [
       // eslint-disable-next-line @typescript-eslint/unbound-method
       Validators.required,
       Validators.pattern(/^[^.].+\.wav$/i)
     ]),
-    loopCount: new FormControl<1 | 2| 4>(1),
+    loopCount: new FormControl<1 | 2 | 4>(1),
     exportWithTail: new FormControl<boolean>(true)
   })
 
@@ -41,9 +41,9 @@ export class ExportAudioModalComponent extends BaseExportModalComponent<AudioExp
 
   override options: AudioExportOptions = DEFAULT_EXPORT_OPTIONS;
 
-  override onExport(): void {
+  override onValidate(): void {
     if (this.form.valid) {
-      this.export.emit({
+      this.validate.emit({
         fileName: this.form.controls.fileName.value!,
         loopCount: this.form.controls.loopCount.value!,
         exportWithTail: this.form.controls.exportWithTail.value!,

--- a/frontend/src/app/ui/components/modals/export-midi-modal/export-midi-modal.component.html
+++ b/frontend/src/app/ui/components/modals/export-midi-modal/export-midi-modal.component.html
@@ -1,39 +1,41 @@
 @if(isOpen){
-  <div class="modal-overlay" (click)="onOverlayClick($event)">
-    <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="exportMidiDialogTitle">
-      <div class="modal-header">
-        <h2 id="exportMidiDialogTitle">{{ 'exportMidi.title' | translate }}</h2>
-        <button class="close-btn" aria-label="Close MIDI export dialog" (click)="onClose()">×</button>
-      </div>
+<div class="modal-overlay" (click)="onOverlayClick($event)">
+  <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="exportMidiDialogTitle">
+    <div class="modal-header">
+      <h2 id="exportMidiDialogTitle">{{ 'exportMidi.title' | translate }}</h2>
+      <button class="close-btn" aria-label="Close MIDI export dialog" (click)="onClose()">×</button>
+    </div>
 
-      <div class="modal-body" [formGroup]="form">
-        <div class="form-group">
-          @let fileName = form.controls.fileName;
+    <div class="modal-body" [formGroup]="form">
+      <div class="form-group">
+        @let fileName = form.controls.fileName;
 
-          <label for="midiFileName">{{ 'exportMidi.fileName' | translate }}</label>
-          <input id="midiFileName" type="text" [formControl]="fileName" class="beat-name-input" />
+        <label for="midiFileName">{{ 'exportMidi.fileName' | translate }}</label>
+        <input id="midiFileName" type="text" [formControl]="fileName" class="beat-name-input" />
 
-          @if (fileName.invalid && (fileName.dirty || fileName.touched)) {
-            <div>
-              @if (fileName.errors?.['required']) {
-                <small>{{ 'exportMidi.validation.required' | translate }}</small>
-              }
-              @if (fileName.errors?.['pattern']) {
-                <small>{{ 'exportMidi.validation.pattern' | translate }}</small>
-              }
-            </div>
+        @if (fileName.invalid && (fileName.dirty || fileName.touched)) {
+        <div>
+          @if (fileName.errors?.['required']) {
+          <small>{{ 'exportMidi.validation.required' | translate }}</small>
+          }
+          @if (fileName.errors?.['pattern']) {
+          <small>{{ 'exportMidi.validation.pattern' | translate }}</small>
           }
         </div>
-        <div class="flex align-center">
-          <img [ngSrc]="'assets/images/icons/warning.svg' | iconDarkMode" height="28" width="28" class="mr-10" aria-hidden="true" alt="warning-icon"/>
-          <small class="warning-label">{{ 'exportMidi.warning' | translate }}</small>
-        </div>
+        }
       </div>
-
-      <div class="modal-footer">
-        <button class="btn btn-secondary" (click)="onClose()">{{ 'exportMidi.cancel' | translate }}</button>
-        <button class="btn btn-primary" (click)="onExport()" [disabled]="!this.form.valid">{{ 'exportMidi.export' | translate }}</button>
+      <div class="flex align-center">
+        <img [ngSrc]="'assets/images/icons/warning.svg' | iconDarkMode" height="28" width="28" class="mr-10"
+          aria-hidden="true" alt="warning-icon" />
+        <small class="warning-label">{{ 'exportMidi.warning' | translate }}</small>
       </div>
     </div>
+
+    <div class="modal-footer">
+      <button class="btn btn-secondary" (click)="onClose()">{{ 'exportMidi.cancel' | translate }}</button>
+      <button class="btn btn-primary" (click)="onValidate()" [disabled]="!this.form.valid">{{ 'exportMidi.export' |
+        translate }}</button>
+    </div>
   </div>
+</div>
 }

--- a/frontend/src/app/ui/components/modals/export-midi-modal/export-midi-modal.component.spec.ts
+++ b/frontend/src/app/ui/components/modals/export-midi-modal/export-midi-modal.component.spec.ts
@@ -1,7 +1,7 @@
-import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {By} from '@angular/platform-browser';
-import {provideTranslateService} from '@ngx-translate/core';
-import {ExportMidiModalComponent} from "./export-midi-modal.component";
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { provideTranslateService } from '@ngx-translate/core';
+import { ExportMidiModalComponent } from "./export-midi-modal.component";
 
 describe('ExportMidiModalComponent', () => {
   let component: ExportMidiModalComponent;
@@ -102,13 +102,13 @@ describe('ExportMidiModalComponent', () => {
   });
 
   it('should not emit export event if form is invalid', () => {
-    spyOn(component.export, 'emit');
+    spyOn(component.validate, 'emit');
     component.isOpen = true;
     fixture.detectChanges();
 
     component.form.controls.fileName.setValue("test.mp3" as any);
-    component.onExport();
+    component.onValidate();
 
-    expect(component.export.emit).not.toHaveBeenCalled();
+    expect(component.validate.emit).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/ui/components/modals/export-midi-modal/export-midi-modal.component.ts
+++ b/frontend/src/app/ui/components/modals/export-midi-modal/export-midi-modal.component.ts
@@ -1,12 +1,12 @@
-import {Component, EventEmitter, inject, Input, OnChanges, Output, SimpleChanges} from '@angular/core';
-import {FormBuilder, FormControl, FormsModule, ReactiveFormsModule, Validators} from '@angular/forms';
-import {CommonModule, NgOptimizedImage} from '@angular/common';
-import {TranslatePipe} from "@ngx-translate/core";
-import {BaseExportModalComponent} from "../base-export-modal.component";
-import {MidiExportOptions} from "../../../../domain/export-options/midi-export-options";
-import {LoopCount} from "../../../../domain/export-options/audio-export-options";
-import {MidiFilename, toMidiFilename} from "../../../../domain/filenames/midi.filename";
-import {IconDarkModePipe} from "../../../pipes/icon-dark-mode.pipe";
+import { Component, EventEmitter, inject, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { FormBuilder, FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
+import { TranslatePipe } from "@ngx-translate/core";
+import { BaseModalComponent } from "../base-modal.component";
+import { MidiExportOptions } from "../../../../domain/export-options/midi-export-options";
+import { LoopCount } from "../../../../domain/export-options/audio-export-options";
+import { MidiFilename, toMidiFilename } from "../../../../domain/filenames/midi.filename";
+import { IconDarkModePipe } from "../../../pipes/icon-dark-mode.pipe";
 
 @Component({
   selector: 'app-export-midi-modal',
@@ -15,14 +15,14 @@ import {IconDarkModePipe} from "../../../pipes/icon-dark-mode.pipe";
   templateUrl: './export-midi-modal.component.html',
   styleUrl: '../../../../../styles/modals/modal.base.scss'
 })
-export class ExportMidiModalComponent extends BaseExportModalComponent<MidiExportOptions> implements OnChanges {
+export class ExportMidiModalComponent extends BaseModalComponent<MidiExportOptions> implements OnChanges {
   private readonly fb = inject(FormBuilder);
 
   @Input() override isOpen: boolean = false;
   @Input() override beatName: string = 'myFile';
 
   @Output() override close = new EventEmitter<void>();
-  @Output() override export = new EventEmitter<MidiExportOptions>();
+  @Output() override validate = new EventEmitter<MidiExportOptions>();
 
   override options: MidiExportOptions = {
     fileName: toMidiFilename('file.mid')
@@ -49,9 +49,9 @@ export class ExportMidiModalComponent extends BaseExportModalComponent<MidiExpor
     }
   }
 
-  override onExport(): void {
+  override onValidate(): void {
     if (this.form.valid) {
-      this.export.emit({
+      this.validate.emit({
         fileName: this.form.controls.fileName.value!,
       });
     }

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.html
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.html
@@ -73,9 +73,9 @@
 </div>
 
 <app-export-modal [isOpen]="isAudioExportModalOpen" [beatName]="beat.label" (close)="isAudioExportModalOpen = false"
-  (export)="onAudioExport($event)">
+  (validate)="onAudioExport($event)">
 </app-export-modal>
 
 <app-export-midi-modal [isOpen]="isMidiExportModalOpen" [beatName]="beat.label" (close)="isMidiExportModalOpen = false"
-  (export)="onMidiExport($event)">
+  (validate)="onMidiExport($event)">
 </app-export-midi-modal>


### PR DESCRIPTION
I'll use this base modal for the add track feature the the 'export' keyword is unnecessary