### PR TITLE
Refacto : getBeats use effect

### DIFF
--- a/frontend/src/app/domain/ports/i-manage-beats.ts
+++ b/frontend/src/app/domain/ports/i-manage-beats.ts
@@ -1,5 +1,7 @@
-import {Beat} from "../beat";
+import { Effect } from "effect";
+import { Beat } from "../beat";
+import { HttpErrorResponse } from "@angular/common/http";
 
 export default interface IManageBeats {
-  readonly getAllBeats:() => Promise<readonly Beat[]>
+  readonly getAllBeats: () => Effect.Effect<Beat[], HttpErrorResponse | Error>
 }

--- a/frontend/src/app/infrastructure/adapters/beat-source/beat-adapter.service.spec.ts
+++ b/frontend/src/app/infrastructure/adapters/beat-source/beat-adapter.service.spec.ts
@@ -1,17 +1,17 @@
-import {BeatAdapter} from "./beat-adapter.service";
-import {Beat} from "../../../domain/beat";
-import {JsonFilesReaderInterface} from "./json-files-reader.interface";
-import {Observable, of} from "rxjs";
-import {TestBed} from "@angular/core/testing";
-import {CompactBeat} from "./compact-beat";
-import {jsonFileReaderToken} from "../../injection-tokens/json-file-reader.token";
-import {toMp3FilePath} from "../../../domain/filenames/mp3.filepath";
+import { BeatAdapter } from "./beat-adapter.service";
+import { Beat } from "../../../domain/beat";
+import { JsonFilesReaderInterface } from "./json-files-reader.interface";
+import { TestBed } from "@angular/core/testing";
+import { CompactBeat } from "./compact-beat";
+import { jsonFileReaderToken } from "../../injection-tokens/json-file-reader.token";
+import { toMp3FilePath } from "../../../domain/filenames/mp3.filepath";
+import { Effect } from "effect";
 
 describe("Beat adapter service", () => {
 
   const mock: JsonFilesReaderInterface = {
-    loadAllJson(): Observable<CompactBeat[]> {
-      return of([{
+    loadAllJson(): Effect.Effect<CompactBeat[]> {
+      return Effect.succeed([{
         "label": "Metal",
         "genre": "Metal",
         "bpm": 180,
@@ -28,7 +28,7 @@ describe("Beat adapter service", () => {
           },
           {
             "name": "Kick",
-            "fileName":  toMp3FilePath("metal/kick.mp3"),
+            "fileName": toMp3FilePath("metal/kick.mp3"),
             "steps": "XXXXXXXXXXXXXXXX"
           }
         ]
@@ -44,12 +44,12 @@ describe("Beat adapter service", () => {
     }).compileComponents();
   });
 
-  it("should return compact beats",() => {
+  it("should return compact beats", () => {
     //Arrange
     const systemUnderTest = TestBed.inject(BeatAdapter);
 
     //Act
-    systemUnderTest.getAllBeats().then((beats: readonly Beat[]) => {
+    Effect.runPromise(systemUnderTest.getAllBeats()).then((beats: readonly Beat[]) => {
       //Assert
       expect(beats.length).toBeGreaterThan(0);
     })

--- a/frontend/src/app/infrastructure/adapters/beat-source/beat-adapter.service.ts
+++ b/frontend/src/app/infrastructure/adapters/beat-source/beat-adapter.service.ts
@@ -18,9 +18,8 @@ export class BeatAdapter implements IManageBeats {
       this.jsonFileReader.loadAllJson(),
       beats =>
         Effect.all(
-          beats!
-            .filter(x => x != null)
-            .map(CompactBeatMapper.toBeatEffect)
+          beats.filter(x => x != null)
+            .map(beat => CompactBeatMapper.toBeatEffect(beat))
         )
     )
   }

--- a/frontend/src/app/infrastructure/adapters/beat-source/beat-adapter.service.ts
+++ b/frontend/src/app/infrastructure/adapters/beat-source/beat-adapter.service.ts
@@ -1,27 +1,27 @@
 import IManageBeats from "../../../domain/ports/i-manage-beats";
-import {firstValueFrom, map} from "rxjs";
-import {Beat} from "../../../domain/beat";
-import {Inject, Injectable} from "@angular/core";
-import {JsonFilesReaderInterface} from "./json-files-reader.interface";
-import {CompactBeatMapper} from "./compact-beat.mapper";
-import {jsonFileReaderToken} from "../../injection-tokens/json-file-reader.token";
-import {Effect} from "effect";
+import { Beat } from "../../../domain/beat";
+import { Inject, Injectable } from "@angular/core";
+import { JsonFilesReaderInterface } from "./json-files-reader.interface";
+import { CompactBeatMapper } from "./compact-beat.mapper";
+import { jsonFileReaderToken } from "../../injection-tokens/json-file-reader.token";
+import { Effect } from "effect";
+import { HttpErrorResponse } from "@angular/common/http";
 
-@Injectable({providedIn: 'root'})
+@Injectable({ providedIn: 'root' })
 export class BeatAdapter implements IManageBeats {
   constructor(@Inject(jsonFileReaderToken) private readonly jsonFileReader: JsonFilesReaderInterface) {
 
   }
 
-  getAllBeats(): Promise<readonly Beat[]> {
-    return firstValueFrom(this.jsonFileReader.loadAllJson()
-      .pipe(
-        map(beats => beats.filter(x => x != null)),
-        map(beats => Effect.all(
-          beats.map(b => CompactBeatMapper.toBeatEffect(b)),
-          { discard: false, mode: 'either' }
-        )),
-        map(effect => Effect.runSync(effect).filter(x => x._tag === 'Right').map(x => x.right))
-      ))
+  getAllBeats(): Effect.Effect<Beat[], HttpErrorResponse | Error> {
+    return Effect.flatMap(
+      this.jsonFileReader.loadAllJson(),
+      beats =>
+        Effect.all(
+          beats!
+            .filter(x => x != null)
+            .map(CompactBeatMapper.toBeatEffect)
+        )
+    )
   }
 }

--- a/frontend/src/app/infrastructure/adapters/beat-source/json-files-reader.interface.ts
+++ b/frontend/src/app/infrastructure/adapters/beat-source/json-files-reader.interface.ts
@@ -1,7 +1,8 @@
-import {Observable} from "rxjs";
-import {CompactBeat} from "./compact-beat";
+import { HttpErrorResponse } from "@angular/common/http";
+import { CompactBeat } from "./compact-beat";
+import { Effect } from "effect";
 
 export interface JsonFilesReaderInterface {
-  loadAllJson(): Observable<readonly (CompactBeat | null)[]>
+  loadAllJson(): Effect.Effect<readonly (CompactBeat | null)[], HttpErrorResponse>
 }
 

--- a/frontend/src/app/infrastructure/adapters/beat-source/json-files-reader.service.spec.ts
+++ b/frontend/src/app/infrastructure/adapters/beat-source/json-files-reader.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import {JsonFileReader} from "./json-files-reader.service";
-import {Effect} from "effect";
+import { JsonFileReader } from "./json-files-reader.service";
+import { Effect } from "effect";
 
 describe('JsonLoaderService', () => {
   let service: JsonFileReader;

--- a/frontend/src/app/infrastructure/adapters/beat-source/json-files-reader.service.ts
+++ b/frontend/src/app/infrastructure/adapters/beat-source/json-files-reader.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { firstValueFrom, from, Observable } from 'rxjs';
+import { firstValueFrom, Observable } from 'rxjs';
 import { JsonFilesReaderInterface } from "./json-files-reader.interface";
 import { CompactBeat } from "./compact-beat";
 import { Effect } from "effect";

--- a/frontend/src/app/infrastructure/adapters/beat-source/json-files-reader.service.ts
+++ b/frontend/src/app/infrastructure/adapters/beat-source/json-files-reader.service.ts
@@ -1,16 +1,16 @@
-import {HttpClient, HttpErrorResponse} from '@angular/common/http';
-import {Injectable} from '@angular/core';
-import {firstValueFrom, from, Observable} from 'rxjs';
-import {JsonFilesReaderInterface} from "./json-files-reader.interface";
-import {CompactBeat} from "./compact-beat";
-import {Effect} from "effect";
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { firstValueFrom, from, Observable } from 'rxjs';
+import { JsonFilesReaderInterface } from "./json-files-reader.interface";
+import { CompactBeat } from "./compact-beat";
+import { Effect } from "effect";
 
 @Injectable({ providedIn: 'root' })
 export class JsonFileReader implements JsonFilesReaderInterface {
   constructor(private readonly http: HttpClient) {
   }
 
-  loadAllJson(): Observable<readonly (CompactBeat | null)[]> {
+  loadAllJson(): Effect.Effect<readonly (CompactBeat | null)[], HttpErrorResponse> {
     const files = ['hypnotic-techno/tresillo', 'hypnotic-techno/son-clave']
       .concat('techno/techno', 'techno/off-beat-clap')
       .concat('hardcore-techno/gabber')
@@ -22,15 +22,16 @@ export class JsonFileReader implements JsonFilesReaderInterface {
       .concat('rock/rock', 'rock/variation')
       .concat('punk/punk-beat-quarter-note-groove', 'punk/punk-beat-quarter-note-groove-variation', 'punk/punk-beat-eight-note-fill')
       .concat('ebm/ebm')
-    return from(Effect.runPromise(this.loadAllBeats(files)));
+    return this.loadAllBeats(files);
   }
 
-  loadAllBeats = (files: readonly string[]) =>
+  loadAllBeats = (files: readonly string[]): Effect.Effect<readonly (CompactBeat | null)[], HttpErrorResponse> =>
     Effect.all(
-      files.map(file => this.fromObservable(() => this.http.get<CompactBeat>(`/assets/beats/${file}.json`)).pipe(
-        Effect.catchAll(() => Effect.succeed(null))
-      )),
-      { discard: false }
+      files.map(file =>
+        this.fromObservable(() =>
+          this.http.get<CompactBeat>(`/assets/beats/${file}.json`)
+        ).pipe(Effect.catchAll(() => Effect.succeed(null)))
+      )
     );
 
   fromObservable = <A>(obs: () => Observable<A>): Effect.Effect<A, HttpErrorResponse> =>

--- a/frontend/src/app/infrastructure/adapters/json-error.ts
+++ b/frontend/src/app/infrastructure/adapters/json-error.ts
@@ -1,8 +1,0 @@
-class JsonError {
-    readonly _tag = "JsonError";
-
-    constructor(
-        readonly message: string,
-        readonly cause?: unknown
-    ) { }
-}

--- a/frontend/src/app/infrastructure/adapters/json-error.ts
+++ b/frontend/src/app/infrastructure/adapters/json-error.ts
@@ -1,0 +1,8 @@
+class JsonError {
+    readonly _tag = "JsonError";
+
+    constructor(
+        readonly message: string,
+        readonly cause?: unknown
+    ) { }
+}

--- a/frontend/src/app/ui/components/sequencer/sequencer.component.spec.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.component.spec.ts
@@ -14,7 +14,7 @@ import { NumberOfSteps } from "../../../domain/number-of-steps";
 import { BPM } from "../../../domain/bpm";
 import { MidiDrumType } from "../../../domain/midi-drum-type";
 import { provideTranslateService } from "@ngx-translate/core";
-import { Option } from "effect";
+import { Effect, Option } from "effect";
 import { IMIDI } from "../../../infrastructure/injection-tokens/i-midi.token";
 import { MidiExportService } from "../../../infrastructure/adapters/midi-export/midi-exporter.service";
 import { AUDIO_EXPORT } from "../../../infrastructure/injection-tokens/audio-export.token";
@@ -31,7 +31,7 @@ describe('SequencerComponent', () => {
 
   beforeEach(async () => {
     beatsMock = {
-      getAllBeats: () => Promise.resolve([
+      getAllBeats: () => Effect.succeed([
         {
           label: "Techno1",
           genre: "Techno",

--- a/frontend/src/app/ui/components/sequencer/sequencer.service.ts
+++ b/frontend/src/app/ui/components/sequencer/sequencer.service.ts
@@ -7,7 +7,7 @@ import { BehaviorSubject } from "rxjs";
 import { SequencerState } from "src/types/engine";
 import { SequencerViewModel } from "./sequencer.viewmodel";
 import { Beat } from "src/app/domain/beat";
-import { Option } from "effect";
+import { Effect, Option } from "effect";
 import { Track } from "src/app/domain/track";
 
 @Injectable({ providedIn: 'root' })
@@ -52,7 +52,13 @@ export class SequencerService {
   }
 
   async initialize(): Promise<void> {
-    const beats = await this.beatsManager.getAllBeats();
+    console.log("BEGIN")
+
+    const beats = await Effect.runPromise(
+      this.beatsManager.getAllBeats()
+    );
+
+    console.error(beats)
 
     this.genres.clear();
 

--- a/frontend/src/app/ui/router.spec.ts
+++ b/frontend/src/app/ui/router.spec.ts
@@ -1,26 +1,27 @@
-import {ComponentFixture, fakeAsync, flushMicrotasks, TestBed, tick} from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flushMicrotasks, TestBed, tick } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import {SequencerComponent} from "./components/sequencer/sequencer.component";
-import {By} from "@angular/platform-browser";
-import {AppComponent} from "./app.component";
+import { SequencerComponent } from "./components/sequencer/sequencer.component";
+import { By } from "@angular/platform-browser";
+import { AppComponent } from "./app.component";
 import { LoadingBarModule } from '@ngx-loading-bar/core';
-import {IManageBeatsToken} from "../infrastructure/injection-tokens/i-manage-beat.token";
-import {BeatAdapter} from "../infrastructure/adapters/beat-source/beat-adapter.service";
-import {routes} from "./app.module";
-import {AUDIO_ENGINE} from "../infrastructure/injection-tokens/audio-engine.token";
-import {AudioEngineAdapter} from "../infrastructure/adapters/audio-engine/audio-engine.adapter";
-import {Track} from "../domain/track";
-import {BPM} from "../domain/bpm";
-import {provideTranslateService} from "@ngx-translate/core";
-import {provideTranslateHttpLoader} from "@ngx-translate/http-loader";
-import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {IMIDI} from "../infrastructure/injection-tokens/i-midi.token";
-import {MidiExportService} from "../infrastructure/adapters/midi-export/midi-exporter.service";
-import {AUDIO_EXPORT} from "../infrastructure/injection-tokens/audio-export.token";
-import {AudioExportAdapter} from "../infrastructure/adapters/audio-export/audio-export.adapter";
-import {toMp3FilePath} from "../domain/filenames/mp3.filepath";
-import {SequencerService} from "./components/sequencer/sequencer.service";
+import { IManageBeatsToken } from "../infrastructure/injection-tokens/i-manage-beat.token";
+import { BeatAdapter } from "../infrastructure/adapters/beat-source/beat-adapter.service";
+import { routes } from "./app.module";
+import { AUDIO_ENGINE } from "../infrastructure/injection-tokens/audio-engine.token";
+import { AudioEngineAdapter } from "../infrastructure/adapters/audio-engine/audio-engine.adapter";
+import { Track } from "../domain/track";
+import { BPM } from "../domain/bpm";
+import { provideTranslateService } from "@ngx-translate/core";
+import { provideTranslateHttpLoader } from "@ngx-translate/http-loader";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { IMIDI } from "../infrastructure/injection-tokens/i-midi.token";
+import { MidiExportService } from "../infrastructure/adapters/midi-export/midi-exporter.service";
+import { AUDIO_EXPORT } from "../infrastructure/injection-tokens/audio-export.token";
+import { AudioExportAdapter } from "../infrastructure/adapters/audio-export/audio-export.adapter";
+import { toMp3FilePath } from "../domain/filenames/mp3.filepath";
+import { SequencerService } from "./components/sequencer/sequencer.service";
+import { Effect } from "effect";
 
 const beatsProvider = {
   provide: IManageBeatsToken,
@@ -57,13 +58,13 @@ describe('Router', () => {
         {
           provide: IManageBeatsToken,
           useValue: {
-            getAllBeats: () => Promise.resolve([
+            getAllBeats: () => Effect.succeed([
               {
                 label: 'Classic',
                 genre: 'Classic',
                 bpm: BPM(128),
                 tracks: [
-                  new Track("",toMp3FilePath("kick.mp3"), [true, false, true, false, true, false, true, false])
+                  new Track("", toMp3FilePath("kick.mp3"), [true, false, true, false, true, false, true, false])
                 ]
               }
             ])
@@ -82,7 +83,7 @@ describe('Router', () => {
     app.isPortrait = false; // optional, just for clarity
   });
 
-  it('should render the main page', fakeAsync (() => {
+  it('should render the main page', fakeAsync(() => {
     router.initialNavigation();
     tick();
 


### PR DESCRIPTION
Change from getAllBeats : Promise<Beat[]> to getAllBeats: () => Effect.Effect<Beat[], HttpErrorResponse | Error> to use effect instead of Promise

- better error handling in case of a failing http call
- precise typing
- try to learn effect aha