### PR TITLE
ci : make translation check run in parrallel

### DIFF
--- a/.github/actions/angular-test/action.yml
+++ b/.github/actions/angular-test/action.yml
@@ -53,8 +53,3 @@ runs:
         token: ${{ inputs.codecov_token }}
         files: frontend/coverage/ng17-lib-test/lcov.info,frontend/coverage/vitest/lcov.info
         fail_ci_if_error: true
-
-    - name: Verify i18n translations
-      run: bash ./verify_i18n_json.sh
-      shell: bash
-      working-directory: ./frontend

--- a/.github/workflows/angular-deploy-github-pages.yml
+++ b/.github/workflows/angular-deploy-github-pages.yml
@@ -25,9 +25,19 @@ jobs:
       - uses: ./.github/actions/angular-test/
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
+    
+  check-i18n-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        
+      - name: Verify i18n translations consistency
+        run: bash ./verify_i18n_json.sh
+        shell: bash
+        working-directory: ./frontend
 
   build:
-    needs: [validate-angular]
+    needs: [validate-angular, check-i18n-consistency]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,3 +23,13 @@ jobs:
         uses: ./.github/actions/angular-test/
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
+  
+  check-i18n-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Verify i18n translations consistency
+        run: bash ./verify_i18n_json.sh
+        shell: bash
+        working-directory: ./frontend


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CI now fails when Codecov upload encounters an error, improving reporting reliability.
  * Added automated checks to detect inconsistencies in frontend translation files.

* **Chores**
  * Deployment and test workflows now require translation consistency checks to pass before building or completing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->