### PR TITLE
ci: run linter in parallel with angular tests

### DIFF
--- a/.github/actions/angular-lint/action.yml
+++ b/.github/actions/angular-lint/action.yml
@@ -1,9 +1,5 @@
-name: AngularTest
-description: Validate Angular project — Karma, Vitest, coverage, and i18n
-inputs:
-  codecov_token:
-    description: 'Codecov upload token'
-    required: true
+name: AngularLint
+description: Download Scala.js artifact and run ESLint on the Angular project
 runs:
   using: composite
   steps:
@@ -30,19 +26,7 @@ runs:
       shell: bash
       working-directory: ./frontend
 
-    - name: Run angular/karma tests
-      run: npm run test-ci
+    - name: Run ESLint
+      run: npm run lint
       shell: bash
       working-directory: ./frontend
-
-    - name: Run vitest
-      run: npm run test-vitest-coverage
-      shell: bash
-      working-directory: ./frontend
-
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v7
-      with:
-        token: ${{ inputs.codecov_token }}
-        files: frontend/coverage/ng17-lib-test/lcov.info,frontend/coverage/vitest/lcov.info
-        fail_ci_if_error: true

--- a/.github/actions/scala-test/action.yml
+++ b/.github/actions/scala-test/action.yml
@@ -6,6 +6,8 @@ runs:
   steps:
     - name: Checkout repository
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     - name: Setup Java 25 (Temurin)
       uses: actions/setup-java@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Validate Scala
         uses: ./.github/actions/scala-test/
 
@@ -21,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Validate Angular (lint)
         uses: ./.github/actions/angular-lint/
 
@@ -30,6 +34,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Validate Angular (tests)
         uses: ./.github/actions/angular-test/
         with:
@@ -39,6 +45,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Verify i18n translations consistency
         run: bash ./verify_i18n_json.sh
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,34 +1,44 @@
 name: Tests
-
 on:
   pull_request:
     branches: [ "main" ]
     paths: [ 'frontend/**', 'engine/**', '.github/**' ]
   workflow_dispatch:
-
 permissions:
   contents: read
-
 jobs:
-  test:
+  scala:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
-
       - name: Validate Scala
         uses: ./.github/actions/scala-test/
 
-      - name: Validate Angular
+  lint:
+    needs: scala
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Validate Angular (lint)
+        uses: ./.github/actions/angular-lint/
+
+  tests:
+    needs: scala
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Validate Angular (tests)
         uses: ./.github/actions/angular-test/
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
-  
+
   check-i18n-consistency:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-
       - name: Verify i18n translations consistency
         run: bash ./verify_i18n_json.sh
         shell: bash


### PR DESCRIPTION
Closes #533

This change separates the Angular linter from the Angular test job so that both run in parallel after the Scala validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated Angular linting to the CI pipeline.
  - Separated Scala validation, Angular linting, and Angular testing into distinct checks.
  - Preserved Angular test coverage, internationalization, and Codecov reporting.
  - Removed lint execution from the Angular test step to provide clearer, independent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->