### PR TITLE
Fix/modal horizontal scrollbar

### DIFF
--- a/frontend/src/styles/modals/modal.base.scss
+++ b/frontend/src/styles/modals/modal.base.scss
@@ -52,6 +52,7 @@
   margin-bottom: 20px;
   max-height: 200px;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .form-group {


### PR DESCRIPTION
Closes #530

Changes: Prevented horizontal overflow in the modal body (overflow-x: hidden;) .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented horizontal scrolling and content overflow within modal dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->