### PR TITLE
Fix modal close button spacing

### DIFF
--- a/frontend/src/styles/modals/modal.base.scss
+++ b/frontend/src/styles/modals/modal.base.scss
@@ -41,6 +41,7 @@
   font-size: 1.5rem;
   cursor: pointer;
   padding: 4px 8px;
+  margin-left: 16px;
   color: var(--textColor);
 
   &:hover {


### PR DESCRIPTION
## Description

Fixed the spacing of the modal close button.

## Changes

- Added left margin to the modal close button.
- Improved visual separation between the modal content and close button.

## Testing

- Reviewed the CSS change.
- Verified the change is limited to modal styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved modal close-button spacing by adding 16px of left margin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->