### PR TITLE
fix: improve modal close button hover

### DIFF
--- a/frontend/src/styles/modals/modal.base.scss
+++ b/frontend/src/styles/modals/modal.base.scss
@@ -40,12 +40,19 @@
   border: none;
   font-size: 1.5rem;
   cursor: pointer;
-  padding: 4px 8px;
+  width: 32px;
+  height: 32px;
+  padding: 0;
   margin-left: 16px;
+  border-radius: 4px;
   color: var(--textColor);
 
   &:hover {
-    opacity: 0.7;
+    background-color: color-mix(
+      in srgb,
+      var(--textColor) 10%,
+      transparent
+    );
   }
 }
 


### PR DESCRIPTION
Hi !! :) I came across your repository and was interested in contributing, so I decided to work on issue #531.
I updated the close button by giving it a defined clickable area and adding a subtle background on hover, making the button more distinguishable in both light and dark modes.

Changes:

Added a defined 32×32px clickable area to the close button.
Replaced the opacity-based hover with a subtle background highlight.
The hover color is based on --textColor, so it works with both light and dark themes.

For a first contribution, it’s a small UI fix, but I’m happy to contribute!
I'm looking forward to your comments or feedback. Thanks, and see you soon! 😊

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated modal close buttons with a consistent 32×32px size, compact shape, and rounded corners.
  * Improved hover feedback with a subtle background highlight for clearer interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->